### PR TITLE
refactor: Use lowercase identifiers for SharedMediaType enum

### DIFF
--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -32,4 +32,4 @@ class SharedFile {
   }
 }
 
-enum SharedMediaType { TEXT, URL, IMAGE, VIDEO, FILE, OTHER }
+enum SharedMediaType { text, url, image, video, file, other }


### PR DESCRIPTION
Effective dart best practices recommend to use lowercase identifiers for enum