### PR TITLE
Bugfix: Unexisting support for other platforms causes issues

### DIFF
--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,7 +21,7 @@ class SharedFile {
       this.type = SharedMediaType.OTHER});
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value = json['path'],
+      : value = json['value'],
         thumbnail = json['thumbnail'],
         duration = json['duration'],
         type = SharedMediaType.values[json['type']];

--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,7 +21,7 @@ class SharedFile {
       this.type = SharedMediaType.OTHER});
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value = json['value'],
+      : value = json['path'] ?? json['value'],
         thumbnail = json['thumbnail'],
         duration = json['duration'],
         type = SharedMediaType.values[json['type']];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,10 +39,4 @@ flutter:
         pluginClass: FlutterSharingIntentPlugin
       ios:
         pluginClass: FlutterSharingIntentPlugin
-      linux:
-        pluginClass: FlutterSharingIntentPlugin
-      macos:
-        pluginClass: FlutterSharingIntentPlugin
-      windows:
-        pluginClass: FlutterSharingIntentPluginCApi
 


### PR DESCRIPTION
If a given project supports macos, **but want's to use this package only for iOS and Android**, it gets an error when running on macos.

`[!] No podspec found for flutter_sharing_intent in Flutter/ephemeral/.symlinks/plugins/flutter_sharing_intent/macos`

This I believe is because the pubspec falsely declares support for those platforms. At least that is the case for macos, I haven't tested windows or linux.

By removing this lines, the package can be used for the supported platforms (iOS and Android) without affecting the ability to run macos, or not supported platforms.

Related to issues #14 and #13  