### PR TITLE
fix: url not included in shared object

### DIFF
--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,7 +21,7 @@ class SharedFile {
       this.type = SharedMediaType.OTHER});
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value =  json['value'],
+      : value =  json['value'] ?? json['path'],
         thumbnail = json['thumbnail'],
         duration = json['duration'],
         type = SharedMediaType.values[json['type']];


### PR DESCRIPTION
Fixed #29 and #31
The path was not included in the returned `SharingFile`.