### PR TITLE
Workaround for Text Sharing Bug (#50)

### DIFF
--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -104,7 +104,7 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
         eventSinkSharing?.success(value?.toString())
       }
       (intent.type == null || intent.type?.startsWith("text") == true)
-              && intent.action == Intent.ACTION_SEND -> { // Sharing text
+              && (intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing text
 
         val value = getSharingText(intent) ?: getSharingUris(intent)
         if (initial) initialSharing = value

--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -110,6 +110,12 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
         if (initial) initialSharing = value
         latestSharing = value
         Log.w(TAG,"handleIntent ==>> $value")
+        if (value == null) {
+          value = getSharingUris(intent)
+          if (initial) initialSharing = value
+          latestSharing = value
+          Log.w(TAG,"handleIntent ==>> $value")
+        }
         eventSinkSharing?.success(value?.toString())
 
       }

--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -106,16 +106,10 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
       (intent.type == null || intent.type?.startsWith("text") == true)
               && intent.action == Intent.ACTION_SEND -> { // Sharing text
 
-        val value = getSharingText(intent)
+        val value = getSharingText(intent) ?: getSharingUris(intent)
         if (initial) initialSharing = value
         latestSharing = value
         Log.w(TAG,"handleIntent ==>> $value")
-        if (value == null) {
-          value = getSharingUris(intent)
-          if (initial) initialSharing = value
-          latestSharing = value
-          Log.w(TAG,"handleIntent ==>> $value")
-        }
         eventSinkSharing?.success(value?.toString())
 
       }


### PR DESCRIPTION
Text can either be shared as a file or "directly" - both have the same MIME type. This results in the value of the shared item being set to null when a text file is shared (since the code looks for text directly instead of a file path) - see #50.

This PR adds a fallback so that we try finding a shared file if the shared text is null. It is very minimal so it might be worth improving on this by adding an entry to the `SharedMediaType` enum so clients can tell if the text they got from the plugin is regular text or a path to a text file. 