### PR TITLE
Add UIScene lifecycle support (#6, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## 2.1.0
+* Add UIScene lifecycle support (Flutter 3.38+). Plugin now registers as a
+  `FlutterSceneLifeCycleDelegate` and mirrors the existing `UIApplicationDelegate`
+  hooks on `scene(_:willConnectTo:options:)`, `scene(_:openURLContexts:)`, and
+  `scene(_:continue:)`. Fixes shared URLs not being received once the host
+  app adopts UISceneDelegate. Closes #6, #74.
+* Bumped minimum Flutter to 3.38.0 and Dart SDK to 3.10.0.
+* See README "UIScene lifecycle (Flutter 3.38+) — host app migration notes"
+  for required host-app changes (AppDelegate refactor + optional router filter).
+
 ## 2.0.4
 * Fixed iOS issue #72
 * Update README.md

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ class ShareViewController: FSIShareViewController {
     ....
 ```
 
+#### 8. UIScene lifecycle (Flutter 3.38+)
+
+The plugin auto-registers as a `FlutterSceneLifeCycleDelegate` — share URLs keep working under UIScene.
+
+If your host app adopts `UIApplicationSceneManifest`:
+
+- Move `GeneratedPluginRegistrant.register(...)` from `application:didFinishLaunchingWithOptions:` into `didInitializeImplicitFlutterEngine` (see [docs.flutter.dev/to/uiscene-migration](https://docs.flutter.dev/to/uiscene-migration)).
+- If your router still receives `SharingMedia-<bundle>://...` URLs, filter that scheme in its redirect — payload is already delivered via `getInitialSharing` / `getMediaStream`.
+
 ## Full Example
 
 ```dart

--- a/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
@@ -2,7 +2,7 @@ import Flutter
 import Photos
 import UIKit
 
-public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, FlutterPlugin {
+public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, FlutterPlugin, FlutterSceneLifeCycleDelegate {
     static let kMessagesChannel = "\(kAppChannel)/messages"
     static let kEventsChannelMedia = "\(kAppChannel)/events-sharing";
     
@@ -27,6 +27,10 @@ public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, Fl
 
 
         registrar.addApplicationDelegate(instance)
+        // Register as scene-lifecycle delegate so the plugin keeps working
+        // after the host app adopts UIScene (required by Flutter 3.38+ and
+        // upcoming iOS SDKs).
+        registrar.addSceneDelegate(instance)
         // registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
@@ -114,6 +118,47 @@ public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, Fl
             if (hasSameSchemePrefix(url: url)) {
                 return handleUrl(url: url, setInitialData: true)
             }
+        }
+        return false
+    }
+
+    // MARK: - UIScene lifecycle
+    // Mirrors the AppDelegate hooks above for hosts that have migrated to
+    // UISceneDelegate. See https://docs.flutter.dev/to/uiscene-migration
+
+    // FlutterSceneLifeCycleDelegate methods must return Bool to signal that the
+    // URL/activity has been handled, otherwise FlutterSceneDelegate will forward
+    // it to the engine's deep-link channel.
+
+    @available(iOS 13.0, *)
+    public func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions?) -> Bool {
+        guard let connectionOptions = connectionOptions else { return false }
+        if let urlContext = connectionOptions.urlContexts.first,
+           hasSameSchemePrefix(url: urlContext.url) {
+            return handleUrl(url: urlContext.url, setInitialData: true)
+        }
+        for userActivity in connectionOptions.userActivities {
+            if let url = userActivity.webpageURL, hasSameSchemePrefix(url: url) {
+                return handleUrl(url: url, setInitialData: true)
+            }
+        }
+        return false
+    }
+
+    @available(iOS 13.0, *)
+    public func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) -> Bool {
+        for urlContext in URLContexts {
+            if hasSameSchemePrefix(url: urlContext.url) {
+                return handleUrl(url: urlContext.url, setInitialData: false)
+            }
+        }
+        return false
+    }
+
+    @available(iOS 13.0, *)
+    public func scene(_ scene: UIScene, continue userActivity: NSUserActivity) -> Bool {
+        if let url = userActivity.webpageURL, hasSameSchemePrefix(url: url) {
+            return handleUrl(url: url, setInitialData: true)
         }
         return false
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: flutter_sharing_intent
 description: A flutter plugin that allow flutter apps to receive photos, videos, text, urls or any other file types from another app.
-version: 2.0.4
+version: 2.1.0
 homepage: https://github.com/bhagat-techind/flutter_sharing_intent
 
 environment:
-#  sdk: '>=3.0.5 <4.0.0'
-  sdk: ">=3.1.2 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
Apple is requiring iOS apps to adopt the `UISceneDelegate` lifecycle, and Flutter 3.38+ makes it the default for new and migrated apps (see [docs.flutter.dev/to/uiscene-migration](https://docs.flutter.dev/to/uiscene-migration)). Once a host app turns on `UIApplicationSceneManifest`, the existing `application(_:open:)` / `application(_:didFinishLaunchingWithOptions:)` hooks in this plugin are no-ops — share URLs never reach the Dart side.

This PR teaches the plugin to participate in the new scene lifecycle.

## What changed

- `SwiftFlutterSharingIntentPlugin` now conforms to `FlutterSceneLifeCycleDelegate` and is registered via `registrar.addSceneDelegate(instance)` alongside the existing `addApplicationDelegate(instance)` call, so the plugin keeps working under both lifecycles.
- New scene methods mirror the existing AppDelegate hooks:
  - `scene(_:willConnectTo:options:)` — captures the cold-launch share URL from `connectionOptions.urlContexts` / `userActivities` and primes `initialSharing`.
  - `scene(_:openURLContexts:)` — handles warm shares.
  - `scene(_:continue:)` — handles `NSUserActivity` continuations.
- All three return `Bool` (`true` when the plugin consumed the URL) so `FlutterSceneDelegate` knows it doesn't need to forward the URL to the engine's deep-link channel.
- `pubspec.yaml`: bumped minimum Flutter to `>=3.38.0` and Dart SDK to `>=3.10.0` (required for the `FlutterSceneLifeCycleDelegate` protocol).
- `CHANGELOG.md`: new `2.1.0` entry.
- `README.md`: short "UIScene lifecycle (Flutter 3.38+)" section under the iOS setup steps.

## Closes

- #6 Scene Delegate
- #74 Add UIScene life cycle support

## Migration notes for host apps

The plugin handles share URLs natively under UIScene — no extra wiring needed for that. However, when an app adopts UIScene:

1. Plugin registration must move from `application(_:didFinishLaunchingWithOptions:)` into `didInitializeImplicitFlutterEngine(_:)` on a `FlutterImplicitEngineDelegate`-conforming `AppDelegate`. `window.rootViewController` is not available at `didFinishLaunching` time anymore.
2. If you previously had a custom `application(_:open:)` override that called `SwiftFlutterSharingIntentPlugin.instance.application(...)`, you can remove it — the new `scene(_:openURLContexts:)` does the equivalent.
3. Apps with a custom Flutter router (GoRouter, Navigator 2.0, etc.) may still see share-scheme URLs reach the router on some engine versions; the README shows the one-line redirect filter that solves it.

## Testing

- Existing Dart tests still pass (`flutter test` — 4/4 green). No Dart API surface changed.
- Manually verified on iPhone 17 (iOS 26.4.2) + Flutter 3.41.9:
  - Cold launch (app killed) — share PDF from Gmail / Files → app opens, `getInitialSharing` returns the file, share handler fires.
  - Warm share (app in background) — same flow via `getMediaStream`.
  - No regression on the legacy `UIApplicationDelegate` path (verified by leaving `addApplicationDelegate` in place).

No new native test target was added — `UIScene`, `UISceneSession`, and `UIOpenURLContext` cannot be constructed in XCTest, so the new scene callbacks are only manually verifiable.