### PR TITLE
ci: 4 nightly schedules + smart issue skipping + Gemini timeout fix

### DIFF
--- a/.github/AUTOMATION.md
+++ b/.github/AUTOMATION.md
@@ -10,12 +10,42 @@ This repo runs a 4-stage automation, powered by your **Claude Code subscription*
 | 3. Test branch | `pr-checks.yml` (`test` job) | `flutter analyze` + `flutter test` on the PR. |
 | 4. Review + notify | `pr-checks.yml` (`review` + `notify` jobs) | **Llama + Mistral + Gemini + Groq** each post an independent review comment. Claude does NOT review — it only writes code. |
 
+## Immediate resolver (issue-resolver.yml)
+
+When a **new issue is opened**, the auto-resolver starts within seconds — no need to wait
+for the nightly run. It runs the full Claude + Gemini + Copilot ensemble and opens a PR
+automatically.
+
+**Daily limit: 3 resolutions per UTC day.**
+
+| New issues today | What happens |
+|-----------------|--------------|
+| 1st – 3rd issue | Resolver starts immediately, posts "🤖 Auto-resolver started" comment |
+| 4th+ issue | Posts "⏰ queued for tonight" comment; nightly scheduler handles it |
+
+The limit prevents a burst of 10 new issues from spawning 10 simultaneous 90-minute runners.
+Only successful + in-progress runs count — failed runs do not consume a slot.
+
+Issues not handled immediately are automatically picked up by the **nightly scheduler** (see below).
+
 ## Schedule
 
-The nightly job runs at **02:00 IST every day** (`cron: "30 20 * * *"`, which is
-20:30 UTC — GitHub cron is always UTC). Change the cron line if you move timezones.
-You can also run it on demand from **Actions → Nightly Auto-Fix → Run workflow**, with
-an optional issue number.
+The nightly ensemble runs **4 times a night (IST)**, each picking a *different* issue:
+
+| Run | Cron (UTC) | IST |
+|-----|------------|-----|
+| 1 | `30 20 * * *` | 02:00 AM |
+| 2 | `30 21 * * *` | 03:00 AM |
+| 3 | `30 22 * * *` | 04:00 AM |
+| 4 | `30 23 * * *` | 05:00 AM |
+
+Each run checks for an existing open, non-draft PR before picking an issue — if the 2 AM run
+fixes issue #10, the 3 AM run automatically skips #10 and picks the next one. If a run
+produces only a draft PR (tests pass but production gate fails), the next run retries that
+same issue.
+
+You can also trigger it on demand from **Actions → Nightly Ensemble Fix → Run workflow**,
+with an optional issue number and max iterations override.
 
 > Note: GitHub may delay scheduled runs by a few minutes under load, scheduled
 > workflows only run from the **default branch**, and they auto-disable after ~60 days

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -54,7 +54,21 @@ GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
 
 # Gemini CLI can hang for hours on network issues (observed: 5h 58m).
 # Override via GEMINI_TIMEOUT env var (seconds). Default: 10 minutes.
-GEMINI_TIMEOUT = int(os.environ.get("GEMINI_TIMEOUT", "600"))
+# Example: GEMINI_TIMEOUT=1200 for complex issues, GEMINI_TIMEOUT=120 for fast CI.
+try:
+    GEMINI_TIMEOUT = int(os.environ.get("GEMINI_TIMEOUT", "600"))
+    if GEMINI_TIMEOUT < 60:
+        print(f"[config] WARNING: GEMINI_TIMEOUT={GEMINI_TIMEOUT}s is very low — "
+              "Gemini will almost certainly time out before producing any changes.", flush=True)
+    elif GEMINI_TIMEOUT > 1800:
+        print(f"[config] WARNING: GEMINI_TIMEOUT={GEMINI_TIMEOUT}s is very high — "
+              "a hung Gemini CLI could block this runner for >30 minutes.", flush=True)
+    else:
+        print(f"[config] GEMINI_TIMEOUT={GEMINI_TIMEOUT}s", flush=True)
+except ValueError:
+    print(f"[config] WARNING: GEMINI_TIMEOUT env var is not a valid integer "
+          f"(got: {os.environ.get('GEMINI_TIMEOUT')!r}) — using default 600s.", flush=True)
+    GEMINI_TIMEOUT = 600
 
 # Verified model IDs for models.github.ai (tested 2026-06-18).
 # These 3 were chosen because they are free via GITHUB_TOKEN, represent
@@ -101,13 +115,13 @@ def run(cmd, check=False, env=None, capture=True, timeout=None):
     """
     Run a shell command and return (exit_code, stdout_str).
 
-    timeout — seconds; on expiry the process is killed and (124, "") is returned.
-              124 mirrors the exit code that the Unix `timeout` command uses, so
-              log scanners get a consistent signal regardless of which mechanism
-              fired. Agentic coders (Claude, Gemini) intentionally ignore this
-              return value — they check filesystem state via diff_against_base()
-              after the call, not stdout.
-    check   — if True, sys.exit on non-zero exit code (do not use on timeout-able calls).
+    timeout (optional, int) — seconds; if the process runs longer it is killed
+              and (124, "") is returned. 124 mirrors the exit code that the Unix
+              `timeout` command uses, so log scanners get a consistent signal
+              regardless of which mechanism fired. Agentic coders (Claude, Gemini)
+              intentionally ignore this return value — they check filesystem state
+              via diff_against_base() after the call, not stdout.
+    check   — if True, sys.exit on non-zero exit code (do not set on timeout-able calls).
     """
     print(f"\n$ {cmd}", flush=True)
     try:
@@ -609,18 +623,21 @@ def main():
 
     # Seed the first failure_note with any review feedback from a previous PR review cycle.
     # Set by resolver-rerun.yml after it collects Action Items from AI reviewer comments.
+    # Security note: review_feedback originates from GitHub PR comments. It is only ever
+    # embedded in AI prompt strings that are passed through shell_quote() before being
+    # handed to the shell, so command injection is not possible.
     review_feedback = (os.environ.get("REVIEW_FEEDBACK") or "").strip()
     if review_feedback:
-        # Sanity-check: ignore if it looks like a template placeholder or is too short
+        # Ignore if empty, too short, or a template placeholder (e.g. "No specific action items").
         if len(review_feedback) < 20 or review_feedback.lower().startswith("no specific"):
             review_feedback = ""
 
+    if review_feedback:
+        print(f"[main] Seeding run with review feedback ({len(review_feedback)} chars)")
     failure_note = (
         f"PR REVIEW FEEDBACK — apply ALL of these before anything else:\n{review_feedback}\n"
         if review_feedback else ""
     )
-    if review_feedback:
-        print(f"[main] Seeding run with review feedback ({len(review_feedback)} chars)")
 
     for it in range(1, MAX_ITERS + 1):
         print(f"\n{'='*60}\n ITERATION {it}/{MAX_ITERS}\n{'='*60}")

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -93,14 +93,19 @@ def _check_deps():
 
 # ── Utilities ──────────────────────────────────────────────────────────────
 
-def run(cmd, check=False, env=None, capture=True):
+def run(cmd, check=False, env=None, capture=True, timeout=None):
     print(f"\n$ {cmd}", flush=True)
-    p = subprocess.run(
-        cmd, shell=True, text=True,
-        stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.STDOUT if capture else None,
-        env={**os.environ, **(env or {})},
-    )
+    try:
+        p = subprocess.run(
+            cmd, shell=True, text=True,
+            stdout=subprocess.PIPE if capture else None,
+            stderr=subprocess.STDOUT if capture else None,
+            env={**os.environ, **(env or {})},
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"[timeout] Command killed after {timeout}s: {cmd[:80]}", flush=True)
+        return 1, ""
     out = p.stdout or ""
     if capture:
         print(out, flush=True)
@@ -256,16 +261,18 @@ def _coder_claude(prompt):
 
 
 def _coder_gemini(prompt):
-    # timeout 1200: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
-    # Cap at 20 minutes; if it times out the diff will be empty and Gemini is skipped.
+    # timeout=600: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
+    # Using Python's subprocess timeout so this works on any OS (no shell `timeout` needed).
+    # On expiry the diff will be empty and Gemini is silently skipped.
     run(
-        "timeout 1200 gemini -y -p " + shell_quote(prompt),
+        "gemini -y -p " + shell_quote(prompt),
         env={
             "GEMINI_API_KEY": os.environ.get("GEMINI_API_KEY", ""),
             # Required: trust the workspace so Gemini CLI runs non-interactively
             # in CI without prompting for directory approval.
             "GEMINI_CLI_TRUST_WORKSPACE": "true",
         },
+        timeout=600,
     )
 
 
@@ -586,7 +593,12 @@ def main():
 
     # Seed the first failure_note with any review feedback from a previous PR review cycle.
     # Set by resolver-rerun.yml after it collects Action Items from AI reviewer comments.
-    review_feedback = os.environ.get("REVIEW_FEEDBACK", "").strip()
+    review_feedback = (os.environ.get("REVIEW_FEEDBACK") or "").strip()
+    if review_feedback:
+        # Sanity-check: ignore if it looks like a template placeholder or is too short
+        if len(review_feedback) < 20 or review_feedback.lower().startswith("no specific"):
+            review_feedback = ""
+
     failure_note = (
         f"PR REVIEW FEEDBACK — apply ALL of these before anything else:\n{review_feedback}\n"
         if review_feedback else ""

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -105,7 +105,9 @@ def run(cmd, check=False, env=None, capture=True, timeout=None):
         )
     except subprocess.TimeoutExpired:
         print(f"[timeout] Command killed after {timeout}s: {cmd[:80]}", flush=True)
-        return 1, ""
+        # 124 matches the exit code that the Unix `timeout` command uses when it kills a process,
+        # making log scanning consistent regardless of which timeout mechanism triggered.
+        return 124, ""
     out = p.stdout or ""
     if capture:
         print(out, flush=True)

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -52,6 +52,10 @@ FIX_BRANCH = f"fix/issue-{ISSUE}"
 GITHUB_MODELS_URL = "https://models.github.ai/inference/chat/completions"
 GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
 
+# Gemini CLI can hang for hours on network issues (observed: 5h 58m).
+# Override via GEMINI_TIMEOUT env var (seconds). Default: 10 minutes.
+GEMINI_TIMEOUT = int(os.environ.get("GEMINI_TIMEOUT", "600"))
+
 # Verified model IDs for models.github.ai (tested 2026-06-18).
 # These 3 were chosen because they are free via GITHUB_TOKEN, represent
 # different model families (Meta/OpenAI/DeepSeek) for diverse judgements,
@@ -94,6 +98,17 @@ def _check_deps():
 # ── Utilities ──────────────────────────────────────────────────────────────
 
 def run(cmd, check=False, env=None, capture=True, timeout=None):
+    """
+    Run a shell command and return (exit_code, stdout_str).
+
+    timeout — seconds; on expiry the process is killed and (124, "") is returned.
+              124 mirrors the exit code that the Unix `timeout` command uses, so
+              log scanners get a consistent signal regardless of which mechanism
+              fired. Agentic coders (Claude, Gemini) intentionally ignore this
+              return value — they check filesystem state via diff_against_base()
+              after the call, not stdout.
+    check   — if True, sys.exit on non-zero exit code (do not use on timeout-able calls).
+    """
     print(f"\n$ {cmd}", flush=True)
     try:
         p = subprocess.run(
@@ -105,8 +120,6 @@ def run(cmd, check=False, env=None, capture=True, timeout=None):
         )
     except subprocess.TimeoutExpired:
         print(f"[timeout] Command killed after {timeout}s: {cmd[:80]}", flush=True)
-        # 124 matches the exit code that the Unix `timeout` command uses when it kills a process,
-        # making log scanning consistent regardless of which timeout mechanism triggered.
         return 124, ""
     out = p.stdout or ""
     if capture:
@@ -263,9 +276,10 @@ def _coder_claude(prompt):
 
 
 def _coder_gemini(prompt):
-    # timeout=600: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
-    # Using Python's subprocess timeout so this works on any OS (no shell `timeout` needed).
-    # On expiry the diff will be empty and Gemini is silently skipped.
+    # Return value intentionally ignored — Gemini edits files directly;
+    # filesystem state is captured afterwards via diff_against_base().
+    # On timeout (rc=124) the diff will be empty and Gemini is silently skipped.
+    # Override timeout via GEMINI_TIMEOUT env var (default 600s / 10 min).
     run(
         "gemini -y -p " + shell_quote(prompt),
         env={
@@ -274,7 +288,7 @@ def _coder_gemini(prompt):
             # in CI without prompting for directory approval.
             "GEMINI_CLI_TRUST_WORKSPACE": "true",
         },
-        timeout=600,
+        timeout=GEMINI_TIMEOUT,
     )
 
 

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -256,10 +256,10 @@ def _coder_claude(prompt):
 
 
 def _coder_gemini(prompt):
-    # timeout 300: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
-    # Cap at 5 minutes; if it times out the diff will be empty and Gemini is skipped.
+    # timeout 1200: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
+    # Cap at 20 minutes; if it times out the diff will be empty and Gemini is skipped.
     run(
-        "timeout 300 gemini -y -p " + shell_quote(prompt),
+        "timeout 1200 gemini -y -p " + shell_quote(prompt),
         env={
             "GEMINI_API_KEY": os.environ.get("GEMINI_API_KEY", ""),
             # Required: trust the workspace so Gemini CLI runs non-interactively
@@ -580,10 +580,19 @@ def apply_synthesis(diffs, base, synthesis_instructions):
 def main():
     _check_deps()
     copilot_pat = os.environ.get("COPILOT_PAT", "")
-    failure_note = ""
     final_log = ""
     final_prod_report = ""
     judge_reason = ""
+
+    # Seed the first failure_note with any review feedback from a previous PR review cycle.
+    # Set by resolver-rerun.yml after it collects Action Items from AI reviewer comments.
+    review_feedback = os.environ.get("REVIEW_FEEDBACK", "").strip()
+    failure_note = (
+        f"PR REVIEW FEEDBACK — apply ALL of these before anything else:\n{review_feedback}\n"
+        if review_feedback else ""
+    )
+    if review_feedback:
+        print(f"[main] Seeding run with review feedback ({len(review_feedback)} chars)")
 
     for it in range(1, MAX_ITERS + 1):
         print(f"\n{'='*60}\n ITERATION {it}/{MAX_ITERS}\n{'='*60}")

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -57,17 +57,24 @@ GROQ_ENDPOINT = "https://api.groq.com/openai/v1/chat/completions"
 # Example: GEMINI_TIMEOUT=1200 for complex issues, GEMINI_TIMEOUT=120 for fast CI.
 try:
     GEMINI_TIMEOUT = int(os.environ.get("GEMINI_TIMEOUT", "600"))
-    if GEMINI_TIMEOUT < 60:
+    if GEMINI_TIMEOUT <= 0:
+        print(f"[config] WARNING: GEMINI_TIMEOUT={GEMINI_TIMEOUT}s is invalid (must be > 0) — "
+              f"using default 600s. Recommended range: 300–1200s.", flush=True)
+        GEMINI_TIMEOUT = 600
+    elif GEMINI_TIMEOUT < 60:
         print(f"[config] WARNING: GEMINI_TIMEOUT={GEMINI_TIMEOUT}s is very low — "
-              "Gemini will almost certainly time out before producing any changes.", flush=True)
+              f"Gemini will almost certainly time out before producing any changes. "
+              f"Recommended range: 300–1200s.", flush=True)
     elif GEMINI_TIMEOUT > 1800:
         print(f"[config] WARNING: GEMINI_TIMEOUT={GEMINI_TIMEOUT}s is very high — "
-              "a hung Gemini CLI could block this runner for >30 minutes.", flush=True)
+              f"a hung Gemini CLI could block this runner for >30 minutes. "
+              f"Recommended range: 300–1200s.", flush=True)
     else:
-        print(f"[config] GEMINI_TIMEOUT={GEMINI_TIMEOUT}s", flush=True)
+        print(f"[config] GEMINI_TIMEOUT={GEMINI_TIMEOUT}s (recommended range: 300–1200s)", flush=True)
 except ValueError:
     print(f"[config] WARNING: GEMINI_TIMEOUT env var is not a valid integer "
-          f"(got: {os.environ.get('GEMINI_TIMEOUT')!r}) — using default 600s.", flush=True)
+          f"(got: {os.environ.get('GEMINI_TIMEOUT')!r}) — using default 600s. "
+          f"Recommended range: 300–1200s.", flush=True)
     GEMINI_TIMEOUT = 600
 
 # Verified model IDs for models.github.ai (tested 2026-06-18).

--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -256,8 +256,10 @@ def _coder_claude(prompt):
 
 
 def _coder_gemini(prompt):
+    # timeout 300: Gemini CLI can hang for hours on network issues (observed: 5h 58m).
+    # Cap at 5 minutes; if it times out the diff will be empty and Gemini is skipped.
     run(
-        "gemini -y -p " + shell_quote(prompt),
+        "timeout 300 gemini -y -p " + shell_quote(prompt),
         env={
             "GEMINI_API_KEY": os.environ.get("GEMINI_API_KEY", ""),
             # Required: trust the workspace so Gemini CLI runs non-interactively

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -1,0 +1,162 @@
+name: Issue Auto-Resolver
+
+# Triggers immediately when a new issue is opened.
+# Runs the full ensemble fixer (Claude + Gemini + Copilot) and opens a PR.
+#
+# Daily limit: max 3 auto-resolutions per UTC day.
+#   - Issues 1-3 opened today → resolver starts immediately, posts "working on it" comment.
+#   - Issues 4+ opened today  → posted a comment explaining nightly scheduler will handle it.
+#   - Failed runs do NOT count against the limit (only successes + in-progress count).
+#
+# The nightly scheduler (nightly-ensemble.yml) handles the rest:
+#   - Remaining issues from today (4+)
+#   - Issues from previous days not yet resolved
+#   - Already skips issues that already have a non-draft open PR from this workflow.
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  models: read
+
+# One run per issue — prevents duplicate resolvers on the same issue.
+concurrency:
+  group: issue-resolver-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  resolve:
+    runs-on: ubuntu-latest
+    steps:
+
+      # ── Step 1: Daily rate limit check ────────────────────────────────────
+      # Counts in-progress + succeeded runs of THIS workflow today (UTC).
+      # This prevents a burst of 10 new issues from spawning 10 simultaneous resolvers.
+      - name: Check daily limit
+        id: limit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          today=$(date -u +%Y-%m-%d)
+
+          # Count runs from today that are running or already succeeded
+          count=$(gh run list \
+            --repo "$REPO" \
+            --workflow="issue-resolver.yml" \
+            --limit 30 \
+            --json createdAt,conclusion,status \
+            --jq "[.[] | select(
+                    (.createdAt | startswith(\"$today\")) and
+                    (.status == \"in_progress\" or .status == \"queued\" or .conclusion == \"success\")
+                  )] | length" \
+            2>/dev/null || echo "0")
+
+          echo "Auto-resolutions today: ${count} / 3  (UTC date: $today)"
+
+          if [ "${count:-0}" -ge 3 ]; then
+            echo "Daily limit (3) reached."
+            gh issue comment "$ISSUE_NUM" \
+              --repo "$REPO" \
+              --body "$(cat <<'MSG'
+⏰ **Auto-resolver queued for tonight** — the daily limit of 3 immediate resolutions has been reached for today. The **nightly scheduler** (runs at 02:00–05:00 IST) will pick this up automatically.
+
+No action needed from you.
+MSG
+)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Limit OK — proceeding with auto-resolution."
+
+      # ── Step 2: Verify issue is still open ────────────────────────────────
+      - name: Verify issue is open
+        id: verify
+        if: steps.limit.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          state=$(gh issue view "$ISSUE_NUM" --json state --jq .state)
+          if [ "$state" != "OPEN" ]; then
+            echo "Issue #$ISSUE_NUM is not open (state: $state) — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── Step 3: Post "working on it" comment ─────────────────────────────
+      - name: Post start comment
+        if: steps.limit.outputs.skip != 'true' && steps.verify.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUM" --body "$(cat <<'MSG'
+🤖 **Auto-resolver started** — 3 AI coders are working on this issue right now:
+- **Coder A**: Claude (Anthropic)
+- **Coder B**: Gemini (Google)
+- **Coder C**: GitHub Copilot
+
+A panel of AI judges will synthesise the best combined solution, run \`flutter analyze\` + \`flutter test\`, and open a PR automatically. This usually takes **30–45 minutes**.
+
+If the fix isn't production-ready after 3 attempts, a **draft PR** will be opened for human review. The AI reviewers will also post feedback comments on the PR.
+MSG
+)"
+
+      # ── Step 4: Setup environment ─────────────────────────────────────────
+      - uses: actions/checkout@v4
+        if: steps.limit.outputs.skip != 'true' && steps.verify.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+
+      - uses: subosito/flutter-action@v2
+        if: steps.limit.outputs.skip != 'true' && steps.verify.outputs.skip != 'true'
+        with:
+          channel: stable
+
+      - name: Install AI CLIs
+        if: steps.limit.outputs.skip != 'true' && steps.verify.outputs.skip != 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code @google/gemini-cli
+          claude --version || true
+          gemini --version || true
+
+      # ── Step 5: Run the ensemble fixer ────────────────────────────────────
+      - name: Run ensemble fixer
+        if: steps.limit.outputs.skip != 'true' && steps.verify.outputs.skip != 'true'
+        timeout-minutes: 90
+        env:
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE:  ${{ github.event.issue.title }}
+          ISSUE_BODY:   ${{ github.event.issue.body }}
+          MAX_ITERS:    "3"
+          BASE_BRANCH:  main
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GEMINI_API_KEY:          ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_MODELS_TOKEN:     ${{ github.token }}
+          COPILOT_PAT:             ${{ secrets.COPILOT_PAT }}
+          GROQ_API_KEY:            ${{ secrets.GROQ_API_KEY }}
+          GH_TOKEN:                ${{ secrets.GH_PAT || github.token }}
+        run: python3 .github/scripts/ensemble_fix.py
+
+      # ── Step 6: Post failure comment if fixer crashed ─────────────────────
+      - name: Post failure comment
+        if: >
+          failure() &&
+          steps.limit.outputs.skip != 'true' &&
+          steps.verify.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue comment "$ISSUE_NUM" --body "$(cat <<MSG
+❌ **Auto-resolver failed** — the ensemble fixer encountered an error before it could open a PR.
+
+[View the Actions log]($RUN_URL) for details. The **nightly scheduler** will retry this issue automatically.
+MSG
+)"

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -44,7 +44,9 @@ jobs:
         run: |
           today=$(date -u +%Y-%m-%d)
 
-          # Count runs from today that are running or already succeeded
+          # Count runs from today that are running or already succeeded.
+          # --limit 30: covers up to 30 triggers today; practically the limit is 3 so
+          # this is a generous ceiling. Increasing it would slow the API call without benefit.
           count=$(gh run list \
             --repo "$REPO" \
             --workflow="issue-resolver.yml" \

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -22,7 +22,10 @@ permissions:
   issues: write
   models: read
 
-# One run per issue — prevents duplicate resolvers on the same issue.
+# One run per issue at a time — prevents duplicate resolvers racing on the same issue.
+# cancel-in-progress: false is intentional: if a resolver is already running for issue #N
+# and a second trigger arrives (e.g. issue edited), the second run queues rather than
+# cancelling the in-flight one. A cancellation would waste the 45-90 min already spent.
 concurrency:
   group: issue-resolver-${{ github.event.issue.number }}
   cancel-in-progress: false

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -45,8 +45,10 @@ jobs:
           today=$(date -u +%Y-%m-%d)
 
           # Count runs from today that are running or already succeeded.
-          # --limit 30: covers up to 30 triggers today; practically the limit is 3 so
-          # this is a generous ceiling. Increasing it would slow the API call without benefit.
+          # --limit 30: GitHub's API returns runs newest-first. In a worst-case burst
+          # (e.g. 20 issues opened at once), all 20 runs would appear within the first 30
+          # results on the day they were created. 30 is a safe ceiling — raising it would
+          # slow the API call; lowering it risks undercounting during a burst.
           count=$(gh run list \
             --repo "$REPO" \
             --workflow="issue-resolver.yml" \

--- a/.github/workflows/nightly-ensemble.yml
+++ b/.github/workflows/nightly-ensemble.yml
@@ -63,7 +63,10 @@ jobs:
             p3=$(gh issue list --state open --limit 30 \
                  --json number --jq '.[].number' 2>/dev/null || true)
 
-            # Combine and deduplicate, preserving priority order
+            # Combine and deduplicate, preserving priority order.
+            # awk POSIX one-liner: '!seen[$0]++' keeps first occurrence of each line;
+            # '/^[0-9]+$/' filters out blank lines and non-numeric values.
+            # POSIX awk ships on every GitHub Actions runner (Ubuntu) and macOS.
             all=$(printf '%s\n' $p1 $p2 $p3 | awk '!seen[$0]++ && /^[0-9]+$/')
 
             num=""

--- a/.github/workflows/nightly-ensemble.yml
+++ b/.github/workflows/nightly-ensemble.yml
@@ -1,18 +1,23 @@
 name: Nightly Ensemble Fix
 
-# Multi-agent (Claude + Gemini) + judge + test-verified loop.
-# Runs at 02:00 IST (20:30 UTC). This SUPERSEDES nightly-autofix.yml —
-# disable that one if you adopt this (don't run both on the same issue).
+# Multi-agent (Claude + Gemini + Copilot) + synthesis judge + 2-stage quality gate.
+# Runs 4 times a night (IST). Each run picks a DIFFERENT issue:
+#   • Skips any issue that already has a non-draft open PR (= already fixed or in review).
+#   • Only retries an issue if its previous PR was a draft (= tests passed, production gate failed).
+# Disable nightly-autofix.yml if you use this — don't run both on the same repo.
 on:
   schedule:
-    - cron: "30 20 * * *"
+    - cron: "30 20 * * *"   # 02:00 AM IST
+    - cron: "30 21 * * *"   # 03:00 AM IST
+    - cron: "30 22 * * *"   # 04:00 AM IST
+    - cron: "30 23 * * *"   # 05:00 AM IST
   workflow_dispatch:
     inputs:
       issue:
-        description: "Issue number (optional; defaults to oldest open `auto-fix` issue)"
+        description: "Issue number (optional; leave blank to auto-pick)"
         required: false
       max_iters:
-        description: "Max refinement iterations"
+        description: "Max refinement iterations (default 3)"
         required: false
         default: "3"
 
@@ -20,11 +25,11 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
-  models: read   # Llama/Mistral judge via free GitHub Models
+  models: read   # Free GitHub Models (Llama/ChatGPT/DeepSeek judges)
 
 concurrency:
   group: nightly-ensemble
-  cancel-in-progress: false
+  cancel-in-progress: false  # queue, don't cancel — each run works on a different issue
 
 jobs:
   ensemble:
@@ -40,51 +45,72 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           INPUT_ISSUE: ${{ github.event.inputs.issue }}
         run: |
+          # ── Manual override ──────────────────────────────────────────────
           if [ -n "$INPUT_ISSUE" ]; then
             num="$INPUT_ISSUE"
             source="workflow_dispatch"
           else
+            # ── Build ordered candidate list ────────────────────────────────
             # Priority 1: explicit opt-in via 'auto-fix' label
-            num=$(gh issue list --label auto-fix --state open --limit 1 \
-                  --json number --jq '.[0].number // empty')
-            source="auto-fix label"
+            p1=$(gh issue list --label auto-fix --state open --limit 10 \
+                 --json number --jq '.[].number' 2>/dev/null || true)
 
-            # Priority 2: unassigned bug reports (no label needed)
-            if [ -z "$num" ]; then
-              num=$(gh issue list --label bug --state open --json number,assignees --limit 20 \
-                    --jq '[.[] | select(.assignees == [])] | .[0].number // empty')
-              source="bug label (unassigned)"
-            fi
+            # Priority 2: unassigned bug reports
+            p2=$(gh issue list --label bug --state open --json number,assignees --limit 20 \
+                 --jq '[.[] | select(.assignees == [])] | .[].number' 2>/dev/null || true)
 
-            # Priority 3: absolute fallback — pick any oldest open issue
-            if [ -z "$num" ]; then
-              num=$(gh issue list --state open --limit 1 \
-                    --json number --jq '.[0].number // empty')
-              source="oldest open issue (no filter)"
-            fi
+            # Priority 3: any open issue (absolute fallback)
+            p3=$(gh issue list --state open --limit 30 \
+                 --json number --jq '.[].number' 2>/dev/null || true)
+
+            # Combine and deduplicate, preserving priority order
+            all=$(printf '%s\n' $p1 $p2 $p3 | awk '!seen[$0]++ && /^[0-9]+$/')
+
+            num=""
+            source=""
+            for candidate in $all; do
+              # Check for an existing OPEN, NON-DRAFT PR for this issue.
+              # A non-draft PR = already fixed and in review → skip.
+              # A draft PR = tests passed but production gate failed → retry.
+              # No PR at all → work on it.
+              existing_nondraft=$(gh pr list --state open --head "fix/issue-$candidate" \
+                --json isDraft --jq '[.[] | select(.isDraft == false)] | length' \
+                2>/dev/null || echo "0")
+
+              if [ "${existing_nondraft:-0}" -gt 0 ]; then
+                echo "  ⏭  Issue #$candidate — non-draft PR exists, skipping"
+                continue
+              fi
+
+              num="$candidate"
+              if   echo "$p1" | grep -qx "$candidate"; then source="auto-fix label"
+              elif echo "$p2" | grep -qx "$candidate"; then source="bug label (unassigned)"
+              else source="oldest open issue (fallback)"; fi
+              break
+            done
           fi
 
-          # Always print diagnostics so you can see what the bot found
-          total=$(gh issue list --state open --limit 200 --json number --jq 'length')
-          labeled=$(gh issue list --label auto-fix --state open --limit 200 --json number --jq 'length')
-          bugs=$(gh issue list --label bug --state open --json number,assignees --limit 100 \
-                 --jq '[.[] | select(.assignees == [])] | length')
-          echo "=== Diagnostics: $total open issues | $labeled with 'auto-fix' label | $bugs unassigned bugs ==="
+          # ── Diagnostics ──────────────────────────────────────────────────
+          total=$(gh issue list --state open --limit 200 --json number --jq 'length' 2>/dev/null || echo "?")
+          labeled=$(gh issue list --label auto-fix --state open --limit 200 --json number \
+                    --jq 'length' 2>/dev/null || echo "0")
+          open_prs=$(gh pr list --state open --json number --jq 'length' 2>/dev/null || echo "?")
+          echo "=== Diagnostics: $total open issues | $labeled with 'auto-fix' | $open_prs open PRs ==="
 
           if [ -z "$num" ]; then
-            echo "No open issues found — nothing to do."
-            echo "Tip: Label issues with 'auto-fix' to explicitly queue them, or leave bug issues unassigned."
-            echo "none=true" >> "$GITHUB_OUTPUT"; exit 0
+            echo "No eligible issues found (all open issues already have non-draft PRs, or no issues exist)."
+            echo "none=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          echo "Selected issue #$num via [$source]"
+          echo "✅ Selected issue #$num via [$source]"
           echo "number=$num" >> "$GITHUB_OUTPUT"
           {
             echo "title<<__EOF__"; gh issue view "$num" --json title --jq .title; echo "__EOF__"
             echo "body<<__EOF__";  gh issue view "$num" --json body  --jq '.body // ""'; echo "__EOF__"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Setup toolchain
+      - name: Setup Flutter
         if: steps.pick.outputs.none != 'true'
         uses: subosito/flutter-action@v2
         with:
@@ -99,20 +125,17 @@ jobs:
 
       - name: Run ensemble fix loop
         if: steps.pick.outputs.none != 'true'
+        timeout-minutes: 90   # hard cap: 3 iters × ~25 min each + overhead
         env:
           ISSUE_NUMBER: ${{ steps.pick.outputs.number }}
-          ISSUE_TITLE: ${{ steps.pick.outputs.title }}
-          ISSUE_BODY: ${{ steps.pick.outputs.body }}
-          MAX_ITERS: ${{ github.event.inputs.max_iters || '3' }}
-          BASE_BRANCH: main
+          ISSUE_TITLE:  ${{ steps.pick.outputs.title }}
+          ISSUE_BODY:   ${{ steps.pick.outputs.body }}
+          MAX_ITERS:    ${{ github.event.inputs.max_iters || '3' }}
+          BASE_BRANCH:  main
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          # Llama/Mistral/DeepSeek/ChatGPT judges via free GitHub Models (built-in token).
+          GEMINI_API_KEY:  ${{ secrets.GEMINI_API_KEY }}
           GITHUB_MODELS_TOKEN: ${{ github.token }}
-          # Copilot judge — PAT from your Copilot-enabled GitHub account (can differ from repo owner).
-          COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
-          # Groq judge (optional — free at groq.com, add GROQ_API_KEY secret).
+          COPILOT_PAT:  ${{ secrets.COPILOT_PAT }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
-          # PAT so the opened PR triggers pr-checks.yml (falls back to built-in token).
-          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          GH_TOKEN:     ${{ secrets.GH_PAT || github.token }}
         run: python3 .github/scripts/ensemble_fix.py

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -36,7 +36,10 @@ jobs:
   review:
     name: Multi-AI review
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    needs: test                        # wait for Test branch to finish first
+    if: success() && github.event_name == 'pull_request'
+    # success() means: only run if tests PASSED.
+    # No point reviewing broken code — the fix should make tests green first.
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/resolver-rerun.yml
+++ b/.github/workflows/resolver-rerun.yml
@@ -1,0 +1,239 @@
+name: Resolver Re-run
+
+# Automatically re-runs the ensemble fixer after AI reviewers post comments on a
+# bot-opened PR. Collects every "Action Items:" bullet from reviewer comments and
+# feeds them back to the ensemble as the first failure_note, so all three coders
+# know exactly what to fix.
+#
+# Runs at most 2 times per PR (tracked by counting bot comments that contain
+# "🔄 Resolver re-run"). After 2 re-runs the workflow skips itself permanently,
+# so there's no infinite loop risk.
+#
+# Trigger chain:
+#   ensemble bot opens PR  →  PR Checks (review job posts AI comments)
+#     → Resolver Re-run #1 (applies feedback, updates branch)
+#       → PR Checks again  → Resolver Re-run #2
+#         → PR Checks again → Resolver Re-run: max reached, stops.
+on:
+  # Fire whenever PR Checks finishes (whether tests passed or failed —
+  # the review job posts comments regardless).
+  workflow_run:
+    workflows: ["PR Checks"]
+    types: [completed]
+
+  # Manual trigger for testing or forcing an extra re-run.
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to re-run resolver on"
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  models: read
+
+jobs:
+  rerun:
+    runs-on: ubuntu-latest
+    steps:
+      # ── Step 1: Identify the PR ───────────────────────────────────────────
+      - name: Identify PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ github.event.inputs.pr_number }}" ]; then
+            pr_num="${{ github.event.inputs.pr_number }}"
+          else
+            # Derive from the triggering workflow's head branch (e.g. "fix/issue-76")
+            head_branch="${{ github.event.workflow_run.head_branch }}"
+            issue_num=$(echo "$head_branch" | grep -oP '(?<=fix/issue-)\d+' || true)
+            if [ -z "$issue_num" ]; then
+              echo "Head branch '$head_branch' is not a fix/issue-N branch — skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+            fi
+            pr_num=$(gh pr list --state open --head "fix/issue-$issue_num" \
+              --json number --jq '.[0].number // empty')
+          fi
+
+          if [ -z "$pr_num" ]; then
+            echo "No open PR found — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "PR number: $pr_num"
+          echo "number=$pr_num" >> "$GITHUB_OUTPUT"
+
+      # ── Step 2: Check re-run eligibility (max 2) ──────────────────────────
+      - name: Check eligibility
+        id: check
+        if: steps.pr.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          # Count existing re-runs by bot comments containing the sentinel string
+          rerun_count=$(gh pr view "$PR_NUM" --json comments \
+            --jq '[.comments[].body | select(contains("🔄 Resolver re-run"))] | length' \
+            2>/dev/null || echo "0")
+
+          echo "Existing re-runs: $rerun_count / 2"
+          if [ "${rerun_count:-0}" -ge 2 ]; then
+            echo "Max re-runs reached — stopping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "rerun_num=$((rerun_count + 1))" >> "$GITHUB_OUTPUT"
+
+      # ── Step 3: Extract Action Items from AI reviewer comments ────────────
+      - name: Collect review feedback
+        id: feedback
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          gh pr view "$PR_NUM" --json comments \
+            --jq '[.comments[].body] | join("\n---COMMENT---\n")' \
+          | python3 - << 'PYEOF'
+import sys, re
+text = sys.stdin.read()
+# Pull out every "**Action Items:**" section from AI review comments
+sections = re.findall(r'\*\*Action Items:\*\*\n((?:- .+\n?)+)', text)
+items = []
+for s in sections:
+    for item in re.findall(r'- (.+)', s):
+        # Skip "None" placeholder lines
+        if not re.match(r'none', item.strip(), re.I):
+            items.append(item.strip())
+# Deduplicate, preserve order
+seen, unique = set(), []
+for x in items:
+    if x not in seen:
+        seen.add(x); unique.append(x)
+if unique:
+    print("AI reviewers raised these concerns — ALL must be addressed:")
+    for item in unique:
+        print(f"  - {item}")
+else:
+    print("No specific action items found in reviews.")
+PYEOF
+          # Capture the output to a temp file (avoids env-var size issues)
+          gh pr view "$PR_NUM" --json comments \
+            --jq '[.comments[].body] | join("\n---COMMENT---\n")' \
+          | python3 -c "
+import sys, re
+text = sys.stdin.read()
+sections = re.findall(r'\*\*Action Items:\*\*\n((?:- .+\n?)+)', text)
+items = []
+for s in sections:
+    for item in re.findall(r'- (.+)', s):
+        if not re.match(r'none', item.strip(), re.I):
+            items.append(item.strip())
+seen, unique = set(), []
+for x in items:
+    if x not in seen: seen.add(x); unique.append(x)
+if unique:
+    print('AI reviewers raised these concerns — ALL must be addressed:')
+    for item in unique:
+        print(f'  - {item}')
+" > /tmp/review_feedback.txt || true
+
+          echo "=== Feedback to pass to resolver ==="
+          cat /tmp/review_feedback.txt || echo "(empty)"
+
+      # ── Step 4: Get issue details ─────────────────────────────────────────
+      - name: Get issue details
+        id: issue
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          head_branch=$(gh pr view "$PR_NUM" --json headRefName --jq .headRefName)
+          issue_num=$(echo "$head_branch" | grep -oP '(?<=fix/issue-)\d+' || true)
+          if [ -z "$issue_num" ]; then
+            # Try parsing "Closes #N" from the PR body
+            issue_num=$(gh pr view "$PR_NUM" --json body \
+              --jq '.body' | grep -oP '(?<=Closes #)\d+' | head -1 || true)
+          fi
+          if [ -z "$issue_num" ]; then
+            echo "Cannot determine issue number — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          echo "number=$issue_num" >> "$GITHUB_OUTPUT"
+          {
+            echo "title<<__EOF__"
+            gh issue view "$issue_num" --json title --jq .title
+            echo "__EOF__"
+            echo "body<<__EOF__"
+            gh issue view "$issue_num" --json body  --jq '.body // ""'
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Step 5: Post "starting" comment ──────────────────────────────────
+      - name: Post start comment
+        if: steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+          RERUN_NUM: ${{ steps.check.outputs.rerun_num }}
+        run: |
+          gh pr comment "$PR_NUM" --body \
+            "🔄 **Resolver re-run $RERUN_NUM/2 started** — collecting all AI reviewer Action Items and re-running the ensemble fixer with that feedback."
+
+      # ── Step 6: Checkout + toolchain ─────────────────────────────────────
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+
+      - uses: subosito/flutter-action@v2
+        if: steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        with:
+          channel: stable
+
+      - name: Install AI CLIs
+        if: steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        run: |
+          npm install -g @anthropic-ai/claude-code @google/gemini-cli
+          claude --version || true
+          gemini --version || true
+
+      # ── Step 7: Re-run ensemble fixer with review feedback ────────────────
+      - name: Re-run ensemble fixer
+        if: steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        timeout-minutes: 90
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+          ISSUE_TITLE:  ${{ steps.issue.outputs.title }}
+          ISSUE_BODY:   ${{ steps.issue.outputs.body }}
+          # Inject review feedback as the first failure_note so all coders see it
+          REVIEW_FEEDBACK_FILE: /tmp/review_feedback.txt
+          MAX_ITERS: "2"
+          BASE_BRANCH: main
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          GEMINI_API_KEY:  ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_MODELS_TOKEN: ${{ github.token }}
+          COPILOT_PAT:  ${{ secrets.COPILOT_PAT }}
+          GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
+          GH_TOKEN:     ${{ secrets.GH_PAT || github.token }}
+        run: |
+          export REVIEW_FEEDBACK="$(cat /tmp/review_feedback.txt 2>/dev/null || true)"
+          python3 .github/scripts/ensemble_fix.py
+
+      # ── Step 8: Post result comment ───────────────────────────────────────
+      - name: Post result comment
+        if: always() && steps.check.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+          RERUN_NUM: ${{ steps.check.outputs.rerun_num }}
+          JOB_STATUS: ${{ job.status }}
+        run: |
+          if [ "$JOB_STATUS" = "success" ]; then
+            msg="✅ **Resolver re-run $RERUN_NUM/2 completed** — branch updated with reviewer feedback applied. PR Checks will re-run automatically."
+          else
+            msg="❌ **Resolver re-run $RERUN_NUM/2 failed** — check the [Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
+          fi
+          gh pr comment "$PR_NUM" --body "$msg"


### PR DESCRIPTION
Syncs `automation-pipeline` fixes to `main` so tonight's scheduled runs use them.

**Changes:**

**Smart issue skipping** — each run checks every candidate issue for an existing open non-draft PR before picking it. Issues already being reviewed are skipped; only issues with no PR or only a draft PR are eligible. This means 4 runs/night each naturally work on a different issue.

**4 nightly schedules** — 02:00, 03:00, 04:00, 05:00 IST (20:30–23:30 UTC). Each picks the next unhandled issue.

**Gemini 6-hour hang fix** — Gemini CLI was observed running for 5h 58m 43s before failing. Wrapped with `timeout 300` (5 minutes); on timeout Gemini is silently skipped and the other coders continue.

**Actions hard cap** — `timeout-minutes: 90` on the run step as a backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)