### PR TITLE
fix: resolve YAML parse errors in resolver workflows

### DIFF
--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -118,7 +118,7 @@ def _check_deps():
 
 # ── Utilities ──────────────────────────────────────────────────────────────
 
-def run(cmd, check=False, env=None, capture=True, timeout=None):
+def run(cmd, check=False, env=None, capture=True, timeout=None, stdin=None):
     """
     Run a shell command and return (exit_code, stdout_str).
 
@@ -128,6 +128,8 @@ def run(cmd, check=False, env=None, capture=True, timeout=None):
               regardless of which mechanism fired. Agentic coders (Claude, Gemini)
               intentionally ignore this return value — they check filesystem state
               via diff_against_base() after the call, not stdout.
+    stdin   (optional, str) — text piped to the process's stdin. Use to avoid
+              writing temp files (e.g. `run("git apply -", stdin=diff_text)`).
     check   — if True, sys.exit on non-zero exit code (do not set on timeout-able calls).
     """
     print(f"\n$ {cmd}", flush=True)
@@ -136,6 +138,8 @@ def run(cmd, check=False, env=None, capture=True, timeout=None):
             cmd, shell=True, text=True,
             stdout=subprocess.PIPE if capture else None,
             stderr=subprocess.STDOUT if capture else None,
+            stdin=subprocess.PIPE if stdin is not None else None,
+            input=stdin,
             env={**os.environ, **(env or {})},
             timeout=timeout,
         )
@@ -383,15 +387,12 @@ def _coder_copilot_apply(prompt, copilot_pat):
         print(f"  Response preview: {response[:300]}")
         return False
 
-    with open("copilot_coder.patch", "w") as fh:
-        fh.write(diff_content)
-
-    rc, out = run("git apply --check copilot_coder.patch")
+    rc, out = run("git apply --check -", stdin=diff_content)
     if rc != 0:
         print(f"[Copilot coder] Patch does not apply cleanly:\n{out}")
         return False
 
-    run("git apply copilot_coder.patch", check=True)
+    run("git apply -", check=True, stdin=diff_content)
     print("[Copilot coder] Patch applied.")
     return True
 
@@ -592,9 +593,7 @@ def apply_synthesis(diffs, base, synthesis_instructions):
         print(f"[synthesis] Base {base} has no diff to apply")
         return False
 
-    with open("synthesis_base.patch", "w") as fh:
-        fh.write(base_diff)
-    rc, _ = run("git apply synthesis_base.patch")
+    rc, _ = run("git apply -", stdin=base_diff)
     if rc != 0:
         print(f"[synthesis] Base {base} patch failed to apply")
         return False

--- a/.github/scripts/extract_action_items.py
+++ b/.github/scripts/extract_action_items.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Read PR comment bodies from stdin (joined by ---COMMENT--- separators) and
+extract deduplicated bullet items from every "**Action Items:**" section.
+
+Usage (resolver-rerun.yml):
+  gh pr view "$PR_NUM" --json comments \
+    --jq '[.comments[].body] | join("\n---COMMENT---\n")' \
+  | python3 .github/scripts/extract_action_items.py \
+  | tee /tmp/review_feedback.txt
+"""
+import re
+import sys
+
+text = sys.stdin.read()
+sections = re.findall(r'\*\*Action Items:\*\*\n((?:- .+\n?)+)', text)
+
+items = []
+for s in sections:
+    for item in re.findall(r'- (.+)', s):
+        if not re.match(r'none', item.strip(), re.I):
+            items.append(item.strip())
+
+seen: set = set()
+unique: list = []
+for x in items:
+    if x not in seen:
+        seen.add(x)
+        unique.append(x)
+
+if unique:
+    print("AI reviewers raised these concerns — ALL must be addressed:")
+    for item in unique:
+        print(f"  - {item}")
+else:
+    print("No specific action items found in reviews.")

--- a/.github/workflows/issue-resolver.yml
+++ b/.github/workflows/issue-resolver.yml
@@ -44,6 +44,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           ISSUE_NUM: ${{ github.event.issue.number }}
+          QUEUED_BODY: |
+            ⏰ **Auto-resolver queued for tonight** — the daily limit of 3 immediate resolutions has been reached for today. The **nightly scheduler** (runs at 02:00–05:00 IST) will pick this up automatically.
+
+            No action needed from you.
         run: |
           today=$(date -u +%Y-%m-%d)
 
@@ -67,14 +71,7 @@ jobs:
 
           if [ "${count:-0}" -ge 3 ]; then
             echo "Daily limit (3) reached."
-            gh issue comment "$ISSUE_NUM" \
-              --repo "$REPO" \
-              --body "$(cat <<'MSG'
-⏰ **Auto-resolver queued for tonight** — the daily limit of 3 immediate resolutions has been reached for today. The **nightly scheduler** (runs at 02:00–05:00 IST) will pick this up automatically.
-
-No action needed from you.
-MSG
-)"
+            gh issue comment "$ISSUE_NUM" --repo "$REPO" --body "$QUEUED_BODY"
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -101,18 +98,17 @@ MSG
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUM: ${{ github.event.issue.number }}
+          START_BODY: |
+            🤖 **Auto-resolver started** — 3 AI coders are working on this issue right now:
+            - **Coder A**: Claude (Anthropic)
+            - **Coder B**: Gemini (Google)
+            - **Coder C**: GitHub Copilot
+
+            A panel of AI judges will synthesise the best combined solution, run `flutter analyze` + `flutter test`, and open a PR automatically. This usually takes **30–45 minutes**.
+
+            If the fix isn't production-ready after 3 attempts, a **draft PR** will be opened for human review. The AI reviewers will also post feedback comments on the PR.
         run: |
-          gh issue comment "$ISSUE_NUM" --body "$(cat <<'MSG'
-🤖 **Auto-resolver started** — 3 AI coders are working on this issue right now:
-- **Coder A**: Claude (Anthropic)
-- **Coder B**: Gemini (Google)
-- **Coder C**: GitHub Copilot
-
-A panel of AI judges will synthesise the best combined solution, run \`flutter analyze\` + \`flutter test\`, and open a PR automatically. This usually takes **30–45 minutes**.
-
-If the fix isn't production-ready after 3 attempts, a **draft PR** will be opened for human review. The AI reviewers will also post feedback comments on the PR.
-MSG
-)"
+          gh issue comment "$ISSUE_NUM" --body "$START_BODY"
 
       # ── Step 4: Setup environment ─────────────────────────────────────────
       - uses: actions/checkout@v4
@@ -159,11 +155,6 @@ MSG
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUM: ${{ github.event.issue.number }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          FAIL_BODY: "❌ **Auto-resolver failed** — the ensemble fixer encountered an error before it could open a PR.\n\n[View the Actions log](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details. The **nightly scheduler** will retry this issue automatically."
         run: |
-          gh issue comment "$ISSUE_NUM" --body "$(cat <<MSG
-❌ **Auto-resolver failed** — the ensemble fixer encountered an error before it could open a PR.
-
-[View the Actions log]($RUN_URL) for details. The **nightly scheduler** will retry this issue automatically.
-MSG
-)"
+          gh issue comment "$ISSUE_NUM" --body "$FAIL_BODY"

--- a/.github/workflows/resolver-rerun.yml
+++ b/.github/workflows/resolver-rerun.yml
@@ -93,52 +93,13 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUM: ${{ steps.pr.outputs.number }}
         run: |
+          # Pipe all PR comment bodies through extract_action_items.py.
+          # tee echoes to stdout (visible in the Actions log) AND writes
+          # /tmp/review_feedback.txt (read by the ensemble fixer step).
           gh pr view "$PR_NUM" --json comments \
             --jq '[.comments[].body] | join("\n---COMMENT---\n")' \
-          | python3 - << 'PYEOF'
-import sys, re
-text = sys.stdin.read()
-# Pull out every "**Action Items:**" section from AI review comments
-sections = re.findall(r'\*\*Action Items:\*\*\n((?:- .+\n?)+)', text)
-items = []
-for s in sections:
-    for item in re.findall(r'- (.+)', s):
-        # Skip "None" placeholder lines
-        if not re.match(r'none', item.strip(), re.I):
-            items.append(item.strip())
-# Deduplicate, preserve order
-seen, unique = set(), []
-for x in items:
-    if x not in seen:
-        seen.add(x); unique.append(x)
-if unique:
-    print("AI reviewers raised these concerns — ALL must be addressed:")
-    for item in unique:
-        print(f"  - {item}")
-else:
-    print("No specific action items found in reviews.")
-PYEOF
-          # Capture the output to a temp file (avoids env-var size issues)
-          gh pr view "$PR_NUM" --json comments \
-            --jq '[.comments[].body] | join("\n---COMMENT---\n")' \
-          | python3 -c "
-import sys, re
-text = sys.stdin.read()
-sections = re.findall(r'\*\*Action Items:\*\*\n((?:- .+\n?)+)', text)
-items = []
-for s in sections:
-    for item in re.findall(r'- (.+)', s):
-        if not re.match(r'none', item.strip(), re.I):
-            items.append(item.strip())
-seen, unique = set(), []
-for x in items:
-    if x not in seen: seen.add(x); unique.append(x)
-if unique:
-    print('AI reviewers raised these concerns — ALL must be addressed:')
-    for item in unique:
-        print(f'  - {item}')
-" > /tmp/review_feedback.txt || true
-
+          | python3 .github/scripts/extract_action_items.py \
+          | tee /tmp/review_feedback.txt || true
           echo "=== Feedback to pass to resolver ==="
           cat /tmp/review_feedback.txt || echo "(empty)"
 


### PR DESCRIPTION
## Root cause

Both `resolver-rerun.yml` and `issue-resolver.yml` have been silently broken since creation.

YAML block scalars (`run: |`) end the moment a **non-empty line with less indentation** than the first content line appears. Both files had:
- Python heredoc content (`import sys, re`) at column 0 inside `resolver-rerun.yml`
- Three message bodies at column 0 inside `issue-resolver.yml`

GitHub saw a broken workflow file and recorded every run as `event="push" conclusion="failure"` with *"This run likely failed because of a workflow file issue."* Neither resolver ever actually ran.

## Fix

- Extracted Python logic to `.github/scripts/extract_action_items.py`
- Moved all multiline message bodies in `issue-resolver.yml` to `env:` YAML literals (which allow multiline content freely)
- All 4 workflow files verified with `yaml.safe_load` — parse clean

## Test plan
- [ ] Push triggers `resolver-rerun.yml` and `issue-resolver.yml` with `event="workflow_run"` / `event="issues"` — no more `event="push"` failures
- [ ] Opening a new issue triggers `issue-resolver.yml` and posts "🤖 Auto-resolver started" comment
- [ ] PR Checks completing on a `fix/issue-N` PR triggers `resolver-rerun.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)