### PR TITLE
fix: remove redundant stdin=PIPE that conflicted with input= in subpr…

### DIFF
--- a/.github/scripts/ensemble_fix.py
+++ b/.github/scripts/ensemble_fix.py
@@ -138,8 +138,7 @@ def run(cmd, check=False, env=None, capture=True, timeout=None, stdin=None):
             cmd, shell=True, text=True,
             stdout=subprocess.PIPE if capture else None,
             stderr=subprocess.STDOUT if capture else None,
-            stdin=subprocess.PIPE if stdin is not None else None,
-            input=stdin,
+            input=stdin,   # subprocess sets stdin=PIPE automatically when input is given
             env={**os.environ, **(env or {})},
             timeout=timeout,
         )


### PR DESCRIPTION
…ocess.run

subprocess.run raises ValueError("stdin and input arguments may not both be used") when both stdin=PIPE and input= are passed together. Passing input= is sufficient — Python sets stdin=PIPE internally.

Broke: git apply - (the patch-via-stdin change from the previous commit)