### PR TITLE
fix: issue #68 (Add platform_interface to plugin structure)

### DIFF
--- a/lib/flutter_sharing_intent.dart
+++ b/lib/flutter_sharing_intent.dart
@@ -1,7 +1,5 @@
 import 'dart:async';
-import 'dart:convert';
 
-import 'package:flutter/services.dart';
 import 'package:flutter_sharing_intent/model/sharing_file.dart';
 
 import 'flutter_sharing_intent_platform_interface.dart';
@@ -9,13 +7,9 @@ import 'flutter_sharing_intent_platform_interface.dart';
 class FlutterSharingIntent {
   static FlutterSharingIntent instance = FlutterSharingIntent._();
   factory FlutterSharingIntent() => instance;
-  late EventChannel _eChannelMedia;
   Stream<List<SharedFile>>? _streamMedia;
 
-  FlutterSharingIntent._() {
-    _eChannelMedia =
-        const EventChannel("flutter_sharing_intent/events-sharing");
-  }
+  FlutterSharingIntent._();
 
   Future<String?> getPlatformVersion() {
     return FlutterSharingIntentPlatform.instance.getPlatformVersion();
@@ -45,24 +39,7 @@ class FlutterSharingIntent {
   /// If the app was started by a link intent or user activity the stream will
   /// not emit that initial one - query either the `getInitialMedia` instead.
   Stream<List<SharedFile>> getMediaStream() {
-    if (_streamMedia == null) {
-      final stream =
-          _eChannelMedia.receiveBroadcastStream("sharing").cast<String?>();
-      _streamMedia = stream.transform<List<SharedFile>>(
-        StreamTransformer<String?, List<SharedFile>>.fromHandlers(
-          handleData: (String? data, EventSink<List<SharedFile>> sink) {
-            if (data == null) {
-              sink.add([]);
-            } else {
-              final encoded = jsonDecode(data);
-              sink.add(encoded
-                  .map<SharedFile>((file) => SharedFile.fromJson(file))
-                  .toList());
-            }
-          },
-        ),
-      );
-    }
+    _streamMedia ??= FlutterSharingIntentPlatform.instance.getMediaStream();
     return _streamMedia!;
   }
 }

--- a/lib/flutter_sharing_intent_method_channel.dart
+++ b/lib/flutter_sharing_intent_method_channel.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -11,6 +12,10 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   final methodChannel = const MethodChannel('flutter_sharing_intent');
+
+  @visibleForTesting
+  final eventChannel =
+      const EventChannel('flutter_sharing_intent/events-sharing');
 
   @override
   Future<String?> getPlatformVersion() async {
@@ -32,5 +37,25 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
     return encoded
         .map<SharedFile>((file) => SharedFile.fromJson(file))
         .toList();
+  }
+
+  @override
+  Stream<List<SharedFile>> getMediaStream() {
+    final stream =
+        eventChannel.receiveBroadcastStream("sharing").cast<String?>();
+    return stream.transform<List<SharedFile>>(
+      StreamTransformer<String?, List<SharedFile>>.fromHandlers(
+        handleData: (String? data, EventSink<List<SharedFile>> sink) {
+          if (data == null) {
+            sink.add([]);
+          } else {
+            final encoded = jsonDecode(data);
+            sink.add(encoded
+                .map<SharedFile>((file) => SharedFile.fromJson(file))
+                .toList());
+          }
+        },
+      ),
+    );
   }
 }

--- a/lib/flutter_sharing_intent_platform_interface.dart
+++ b/lib/flutter_sharing_intent_platform_interface.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_sharing_intent/model/sharing_file.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
@@ -35,5 +37,9 @@ abstract class FlutterSharingIntentPlatform extends PlatformInterface {
 
   void reset() async {
     throw UnimplementedError('reset() has not been implemented.');
+  }
+
+  Stream<List<SharedFile>> getMediaStream() {
+    throw UnimplementedError('getMediaStream() has not been implemented.');
   }
 }

--- a/test/flutter_sharing_intent_test.dart
+++ b/test/flutter_sharing_intent_test.dart
@@ -19,6 +19,9 @@ class MockFlutterSharingIntentPlatform
 
   @override
   void reset() {}
+
+  @override
+  Stream<List<SharedFile>> getMediaStream() => Stream.value([]);
 }
 
 void main() {


### PR DESCRIPTION
        Closes #68

        **Automated ensemble fix**
        | | |
        |---|---|
        | Coders | Claude · Gemini · GitHub Copilot |
        | Judge | Llama + ChatGPT + DeepSeek + Copilot (synthesis, not just pick-one) |
        | Stage 1 oracle | flutter analyze + flutter test |
        | Stage 2 oracle | No warnings · No debug prints · No TODO/FIXME |
        | Status | ✅ Both quality gates passed — production ready |

        > Judge: Majority (2/2) chose A. Candidate A has a well-structured approach and has passed its own tests. Without information about other candidates, it is difficult to determine if this is the best overall approach, but it appears to be a good starting point. | Candidate A provides the best overall structure and approach by refactoring the plugin to use the platform interface, simplifying the `FlutterSharingIntent` class, and implementing the `getMediaStream` method in the platform interface. The explicit addition of the `eventChannel` property and the mock implementation for testing from Candidate A further enhance clarity and maintainability. These improvements result in a production-ready solution that adheres to best practices for Flutter plugin development.

        <details><summary>Production gate report</summary>

        ✅ Production gate passed — no warnings, no debug prints, no TODO/FIXME.
        </details>

        <details><summary>Final test log</summary>

        ```
        ### flutter pub get (exit 0)
Resolving dependencies...
Downloading packages...
  matcher 0.12.19 (0.12.20 available)
  meta 1.18.0 (1.18.3 available)
  test_api 0.7.11 (0.7.12 available)
  vector_math 2.2.0 (2.4.0 available)
Got dependencies!
4 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...
Downloading packages...
Got dependencies in `./example`.


### flutter analyze (exit 0)
Analyzing flutter_sharing_intent...                             
No issues found! (ran in 7.5s)


### flutter test (exit 0)

✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: MethodChannelFlutterSharingIntent is the default instance
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getPlatformVersion
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getInitialSharing
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_method_channel_test.dart: getPlatformVersion

🎉 4 tests passed.

        ```
        </details>
