### PR TITLE
fix: issue #63 (MissingPluginException - No implementation found for me)

### DIFF
--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -301,16 +301,20 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
   }
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-    Log.d(TAG,"onListen ==>> $arguments, $events")
+    Log.d(TAG, "onListen: arguments=$arguments, initialSharing=${initialSharing != null}, latestSharing=${latestSharing != null}")
+    if (events == null) return
     when (arguments) {
-//      "sharing" -> eventSinkSharing = events
       "sharing" -> {
         eventSinkSharing = events
-
-        latestSharing?.let {
-          Log.d(TAG, "Sending cached sharing data onListen: $it")
-          if (eventSinkSharing != null) {
+        // Deliver any sharing data that arrived while no listener was registered,
+        // but only when it is NOT the cold-start intent (initialSharing != null means
+        // the cold-start data is still pending and should be retrieved via
+        // getInitialSharing() to avoid duplicating it here).
+        if (initialSharing == null) {
+          latestSharing?.let {
+            Log.d(TAG, "onListen: sending cached sharing data, latestSharing=$it")
             eventSinkSharing?.success(it.toString())
+            latestSharing = null
           }
         }
       }


### PR DESCRIPTION
        Closes #63

        **Automated ensemble fix**
        | | |
        |---|---|
        | Coders | Claude · Gemini · GitHub Copilot |
        | Judge | Llama + ChatGPT + DeepSeek + Copilot (synthesis, not just pick-one) |
        | Stage 1 oracle | flutter analyze + flutter test |
        | Stage 2 oracle | No warnings · No debug prints · No TODO/FIXME |
        | Status | ⚠️ DRAFT — see details below before merging |

        > Tests pass but production gate found issues. Judge: Majority (3/3) chose A. Candidate A provides a basic structure for handling intents and exceptions, which is a good starting point. By adding null checks and ensuring proper intent data handling, we can make the code more robust and less prone to errors, providing a better production-ready result. | Candidate A provides the most comprehensive and structured base solution, addressing the core issue with proper exception handling and initialization. Candidate B's null checks add an extra layer of safety, and Candidate C's enhanced logging improves maintainability and debugging. Combining these elements results in a robust and production-ready fix.

        <details><summary>Production gate report</summary>

        Production gate FAILED:
Debug print statements in added code:
    Log.d(TAG, "onNewIntent ==>> action=${intent.action}, type=${intent.type}")
      Log.e(TAG, "Error handling new intent", e)
    Log.d(TAG, "onAttachedToActivity ==>> activity=${binding.activity}")
        Log.e(TAG, "Error handling initial intent", e)
      Log.w(TAG, "onAttachedToActivity: activity intent is null, skipping handleIntent")
        </details>

        <details><summary>Final test log</summary>

        ```
        ### flutter pub get (exit 0)
Resolving dependencies...
Downloading packages...
  matcher 0.12.19 (0.12.20 available)
  meta 1.18.0 (1.18.3 available)
  test_api 0.7.11 (0.7.12 available)
  vector_math 2.2.0 (2.4.0 available)
Got dependencies!
4 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...
Downloading packages...
Got dependencies in `./example`.


### flutter analyze (exit 0)
Analyzing flutter_sharing_intent...                             
No issues found! (ran in 7.3s)


### flutter test (exit 0)

✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: MethodChannelFlutterSharingIntent is the default instance
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getPlatformVersion
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getInitialSharing
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_method_channel_test.dart: getPlatformVersion

🎉 4 tests passed.

        ```
        </details>
