### PR TITLE
ci: merge automation pipeline fixes to main

### DIFF
--- a/.github/workflows/resolver-rerun.yml
+++ b/.github/workflows/resolver-rerun.yml
@@ -90,7 +90,16 @@ jobs:
           fi
           echo "rerun_num=$((rerun_count + 1))" >> "$GITHUB_OUTPUT"
 
-      # ── Step 3: Extract Action Items from AI reviewer comments ────────────
+      # ── Step 3: Checkout repo ─────────────────────────────────────────────
+      # Must happen before Step 4 so .github/scripts/extract_action_items.py
+      # is available on the runner's filesystem.
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.skip != 'true'
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_PAT || github.token }}
+
+      # ── Step 4: Extract Action Items from AI reviewer comments ────────────
       - name: Collect review feedback
         id: feedback
         if: steps.check.outputs.skip != 'true'
@@ -117,7 +126,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
-      # ── Step 4: Get issue details ─────────────────────────────────────────
+      # ── Step 5: Get issue details ─────────────────────────────────────────
       - name: Get issue details
         id: issue
         if: steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true'
@@ -146,7 +155,7 @@ jobs:
             echo "__EOF__"
           } >> "$GITHUB_OUTPUT"
 
-      # ── Step 5: Post "starting" comment ──────────────────────────────────
+      # ── Step 6: Post "starting" comment ──────────────────────────────────
       - name: Post start comment
         if: steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
         env:
@@ -157,13 +166,7 @@ jobs:
           gh pr comment "$PR_NUM" --body \
             "🔄 **Resolver re-run $RERUN_NUM/2 started** — collecting all AI reviewer Action Items and re-running the ensemble fixer with that feedback."
 
-      # ── Step 6: Checkout + toolchain ─────────────────────────────────────
-      - uses: actions/checkout@v4
-        if: steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GH_PAT || github.token }}
-
+      # ── Step 7: Toolchain ─────────────────────────────────────────────────
       - uses: subosito/flutter-action@v2
         if: steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
         with:
@@ -176,7 +179,7 @@ jobs:
           claude --version || true
           gemini --version || true
 
-      # ── Step 7: Re-run ensemble fixer with review feedback ────────────────
+      # ── Step 8: Re-run ensemble fixer with review feedback ────────────────
       - name: Re-run ensemble fixer
         if: steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
         timeout-minutes: 90
@@ -198,7 +201,7 @@ jobs:
           export REVIEW_FEEDBACK="$(cat /tmp/review_feedback.txt 2>/dev/null || true)"
           python3 .github/scripts/ensemble_fix.py
 
-      # ── Step 8: Post result comment ───────────────────────────────────────
+      # ── Step 9: Post result comment ───────────────────────────────────────
       - name: Post result comment
         if: always() && steps.check.outputs.skip != 'true' && steps.feedback.outputs.skip != 'true' && steps.issue.outputs.skip != 'true'
         env:


### PR DESCRIPTION
## Summary

Merges 17 CI/pipeline commits from `automation-pipeline` into `main` so all workflow scripts and helpers are live on the default branch.

Key fixes included:
- `extract_action_items.py` — new helper script referenced by `resolver-rerun.yml` (was missing from main, causing every resolver re-run to skip with "No such file or directory")
- `resolver-rerun.yml` — checkout moved to **before** the step that calls `extract_action_items.py`
- `ensemble_fix.py` — `gh pr create --title` now uses `shell_quote()` so issue titles with `'` single quotes don't break the shell command; added exit-code check so "PR opened" only prints on success (fixes same-issue repeat picks)
- `ensemble_fix.py` + `multi_ai_review.py` — Copilot token endpoint fallback (`v2/token` → `token`), Gemini 429 rate-limit sleep (65 s between model retries)
- `issue-resolver.yml` + `nightly-ensemble.yml` + `resolver-rerun.yml` — GH_PAT checkout so bot pushes don't require maintainer approval on subsequent PR Checks runs
- YAML block scalar fixes that were silently breaking both resolver workflows

## Test plan

- [ ] Merge this PR
- [ ] Trigger `resolver-rerun` manually via `workflow_dispatch` on an open fix PR — confirm it finds and uses `extract_action_items.py`
- [ ] Confirm next nightly run opens a PR with a properly quoted title even for issues whose titles contain single quotes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)