### PR TITLE
fix: issue #37 (Sharing text is null when simulating app kill by Androi)

### DIFF
--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -101,20 +101,22 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
 
 
           val value = getSharingUris(intent)
-          if (initial) initialSharing = value
+          if (value == null) Log.w(TAG,"Image/Video : handleIntent ==>> value is null, skipping assignment")
+          if (initial && value != null) initialSharing = value
           latestSharing = value
           Log.w(TAG,"Image/Video : handleIntent ==>> $value")
-          eventSinkSharing?.success(value?.toString())
+          eventSinkSharing?.success(value?.toString() ?: "")
         }
         (intent.type == null || intent.type?.startsWith("text") == true)
                 && (intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing text
 
           val value = getSharingText(intent) ?: getSharingUris(intent)
-          if (initial) initialSharing = value
+          if (value == null) Log.w(TAG,"text : handleIntent ==>> value is null, skipping assignment")
+          if (initial && value != null) initialSharing = value
           latestSharing = value
           Log.w(TAG,"text : handleIntent ==>> $value")
 //          Log.w(TAG,"text : handleIntent ==>> ${eventSinkSharing!=null}")
-          eventSinkSharing?.success(value?.toString())
+          eventSinkSharing?.success(value?.toString() ?: "")
 
         }
         intent.action == Intent.ACTION_VIEW -> { // Opening URL
@@ -123,10 +125,11 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
               .put("value", intent.dataString)
               .put("type", MediaType.URL.ordinal)
           )
-          if (initial) initialSharing = value
+          if (value == null) Log.w(TAG,"ACTION_VIEW : handleIntent ==>> value is null, skipping assignment")
+          if (initial && value != null) initialSharing = value
           latestSharing = value
           Log.w(TAG,"ACTION_VIEW : handleIntent ==>> $value")
-          eventSinkSharing?.success(value?.toString())
+          eventSinkSharing?.success(value?.toString() ?: "")
         }
         intent.action == Intent.ACTION_WEB_SEARCH -> {
             val value = JSONArray().put(
@@ -134,10 +137,11 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
                     .put("value", intent.getStringExtra(SearchManager.QUERY))
                     .put("type", MediaType.WEB_SEARCH.ordinal)
             )
-            if (initial) initialSharing = value
+            if (value == null) Log.w(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> value is null, skipping assignment")
+            if (initial && value != null) initialSharing = value
             latestSharing = value
             Log.w(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> $value")
-            eventSinkSharing?.success(value?.toString())
+            eventSinkSharing?.success(value?.toString() ?: "")
         }
       }
     }


### PR DESCRIPTION
        Closes #37

        **Automated ensemble fix**
        | | |
        |---|---|
        | Coders | Claude · Gemini · GitHub Copilot |
        | Judge | Llama + ChatGPT + DeepSeek + Copilot (synthesis, not just pick-one) |
        | Stage 1 oracle | flutter analyze + flutter test |
        | Stage 2 oracle | No warnings · No debug prints · No TODO/FIXME |
        | Status | ⚠️ DRAFT — see details below before merging |

        > Tests pass but production gate found issues. Judge: Majority (3/3) chose A. Candidate A has the best overall approach by introducing null checks for the sharing values before assigning them to initialSharing or latestSharing, preventing potential NullPointerExceptions. By applying this logic consistently throughout the handleIntent function, we can ensure the code is more robust and less prone to errors when handling sharing intents. | Candidate A provides a clear and concise fix for the issue by adding null checks to prevent assigning null values to `initialSharing`. This approach directly addresses the problem described in issue #37. While Candidate A's solution is solid, ensuring that `eventSinkSharing?.success(value?.toString())` is robust against null values will further improve the reliability of the code. No other candidates provided additional improvements or alternative approaches that were superior to Candidate A's solution.

        <details><summary>Production gate report</summary>

        Production gate FAILED:
Debug print statements in added code:
          if (value == null) Log.w(TAG,"Image/Video : handleIntent ==>> value is null, skipping assignment")
          if (value == null) Log.w(TAG,"text : handleIntent ==>> value is null, skipping assignment")
          if (value == null) Log.w(TAG,"ACTION_VIEW : handleIntent ==>> value is null, skipping assignment")
            if (value == null) Log.w(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> value is null, skipping assignment")
        </details>

        <details><summary>Final test log</summary>

        ```
        ### flutter pub get (exit 0)
Resolving dependencies...
Downloading packages...
  matcher 0.12.19 (0.12.20 available)
  meta 1.18.0 (1.18.3 available)
  test_api 0.7.11 (0.7.13 available)
  vector_math 2.2.0 (2.4.0 available)
Got dependencies!
4 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
Resolving dependencies in `./example`...
Downloading packages...
Got dependencies in `./example`.


### flutter analyze (exit 0)
Analyzing flutter_sharing_intent...                             
No issues found! (ran in 7.4s)


### flutter test (exit 0)

✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: MethodChannelFlutterSharingIntent is the default instance
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getPlatformVersion
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_test.dart: getInitialSharing
✅ /home/runner/work/flutter_sharing_intent/flutter_sharing_intent/test/flutter_sharing_intent_method_channel_test.dart: getPlatformVersion

🎉 4 tests passed.

        ```
        </details>
