### PR TITLE
docs: add troubleshooting for Xcode build cycle error

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,3 +392,8 @@ class _MyAppState extends State<MyApp> {
 
 * Error: Invalid Bundle. The bundle at 'Runner.app/Plugins/Sharing Extension.appex' contains disallowed file 'Frameworks'
     * Fix: https://stackoverflow.com/a/25789145/2061365
+
+* Error (Xcode): Cycle inside Runner; building could produce unreliable results.
+  * This build cycle is triggered when the `Embed App Extensions` phase runs after `Thin Binary` in the Runner target's Build Phases. Xcode ends up with a circular dependency between copying the `.appex` bundle and stripping/processing binaries.
+  * Fix: In Xcode, open your **Runner** target → **Build Phases** tab. Drag the **Embed Foundation Extensions** (or **Embed App Extensions**) phase so it appears **above** the **Thin Binary** phase. Clean the build folder (`Product → Clean Build Folder`) and rebuild.
+  * Reference: [Flutter issue #135739](https://github.com/flutter/flutter/issues/135739)


### PR DESCRIPTION
## Summary

- Adds a new troubleshooting entry in `README.md` for the **"Cycle inside Runner; building could produce unreliable results"** Xcode build error (#36)
- Documents the root cause: `Embed App Extensions` phase ordered after `Thin Binary`, creating a circular dependency in Xcode's build system
- Documents the fix: drag `Embed Foundation Extensions` above `Thin Binary` in Build Phases and clean the build folder
- Links to the upstream Flutter issue [flutter/flutter#135739](https://github.com/flutter/flutter/issues/135739)

Closes #36

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm troubleshooting step resolves the Xcode build cycle for a Share Extension setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)