### PR TITLE
fix: correct SharedMediaType usage in example and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,8 +314,8 @@ class ShareViewController: FSIShareViewController {
 ## Full Example
 
 ```dart
-import 'package:flutter/material.dart';
 import 'dart:async';
+import 'package:flutter/material.dart';
 import 'package:flutter_sharing_intent/flutter_sharing_intent.dart';
 import 'package:flutter_sharing_intent/model/sharing_file.dart';
 
@@ -333,44 +333,65 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   late StreamSubscription _intentDataStreamSubscription;
   List<SharedFile>? list;
+
   @override
   void initState() {
     super.initState();
-    // For sharing images coming from outside the app while the app is in the memory
-    _intentDataStreamSubscription = FlutterSharingIntent.instance.getMediaStream()
+    // For sharing coming from outside the app while the app is in memory
+    _intentDataStreamSubscription = FlutterSharingIntent.instance
+        .getMediaStream()
         .listen((List<SharedFile> value) {
-      setState(() {
-        list = value;
-      });
-      print("Shared: getMediaStream ${value.map((f) => f.value).join(",")}");
+      setState(() => list = value);
+      _handleSharedFiles(value);
     }, onError: (err) {
       print("getIntentDataStream error: $err");
     });
 
-    // For sharing images coming from outside the app while the app is closed
-    FlutterSharingIntent.instance.getInitialSharing().then((List<SharedFile> value) {
-      print("Shared: getInitialMedia ${value.map((f) => f.value).join(",")}");
-      setState(() {
-        list = value;
-      });
+    // For sharing coming from outside the app while the app is closed
+    FlutterSharingIntent.instance
+        .getInitialSharing()
+        .then((List<SharedFile> value) {
+      setState(() => list = value);
+      _handleSharedFiles(value);
     });
+  }
+
+  // Always check file.type on each individual SharedFile in a loop.
+  // Do NOT compare list.map((f) => f.type) to an enum — that always returns false.
+  void _handleSharedFiles(List<SharedFile> sharedFiles) {
+    for (final file in sharedFiles) {
+      switch (file.type) {
+        case SharedMediaType.URL:
+          print("Shared URL: ${file.value}");
+        case SharedMediaType.TEXT:
+          print("Shared text: ${file.value}");
+        case SharedMediaType.IMAGE:
+          print("Shared image path: ${file.value}");
+        case SharedMediaType.VIDEO:
+          print("Shared video: ${file.value}, thumbnail: ${file.thumbnail}");
+        case SharedMediaType.FILE:
+          print("Shared file: ${file.value}, mimeType: ${file.mimeType}");
+        default:
+          print("Shared other: ${file.value}");
+      }
+    }
   }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
-        appBar: AppBar(
-          title: const Text('Plugin example app'),
-        ),
+        appBar: AppBar(title: const Text('Plugin example app')),
         body: Center(
           child: Container(
-              margin: EdgeInsets.symmetric(horizontal: 24),
-              child: Text('Sharing data: \n${list?.join("\n\n")}\n')),
+            margin: const EdgeInsets.symmetric(horizontal: 24),
+            child: Text('Sharing data: \n${list?.join("\n\n")}\n'),
+          ),
         ),
       ),
     );
   }
+
   @override
   void dispose() {
     _intentDataStreamSubscription.cancel();
@@ -378,6 +399,10 @@ class _MyAppState extends State<MyApp> {
   }
 }
 ```
+
+> **Tip:** Always check `file.type` on each individual `SharedFile` in a loop.
+> Comparing `sharedFiles.map((f) => f.type) == SharedMediaType.URL` compares an
+> `Iterable` to an enum value and always returns `false`.
 
 ## Troubleshooting
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,34 +28,62 @@ class _MyAppState extends State<MyApp> {
   }
 
   void initSharingListener() {
-    // For sharing images coming from outside the app while the app is in the memory
+    // For sharing coming from outside the app while the app is in memory
     _intentDataStreamSubscription = FlutterSharingIntent.instance
         .getMediaStream()
         .listen((List<SharedFile> value) {
       setState(() {
         list = value;
       });
-      if (kDebugMode) {
-        print(" Shared: getMediaStream ${value.map((f) => f.value).join(",")}");
-      }
+      _handleSharedFiles(value);
     }, onError: (err) {
       if (kDebugMode) {
         print("Shared: getIntentDataStream error: $err");
       }
     });
 
-    // For sharing images coming from outside the app while the app is closed
+    // For sharing coming from outside the app while the app is closed
     FlutterSharingIntent.instance
         .getInitialSharing()
         .then((List<SharedFile> value) {
-      if (kDebugMode) {
-        print(
-            "Shared: getInitialMedia => ${value.map((f) => f.value).join(",")}");
-      }
       setState(() {
         list = value;
       });
+      _handleSharedFiles(value);
     });
+  }
+
+  void _handleSharedFiles(List<SharedFile> sharedFiles) {
+    for (final file in sharedFiles) {
+      switch (file.type) {
+        case SharedMediaType.URL:
+          if (kDebugMode) {
+            print("Shared URL: ${file.value}");
+          }
+        case SharedMediaType.TEXT:
+          if (kDebugMode) {
+            print("Shared text: ${file.value}");
+          }
+        case SharedMediaType.IMAGE:
+          if (kDebugMode) {
+            print("Shared image path: ${file.value}");
+          }
+        case SharedMediaType.VIDEO:
+          if (kDebugMode) {
+            print(
+                "Shared video path: ${file.value}, thumbnail: ${file.thumbnail}");
+          }
+        case SharedMediaType.FILE:
+          if (kDebugMode) {
+            print(
+                "Shared file path: ${file.value}, mimeType: ${file.mimeType}");
+          }
+        default:
+          if (kDebugMode) {
+            print("Shared other: ${file.value}");
+          }
+      }
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary

- Fixes the confusion reported in #31 where users compared `sharedFiles.map((f) => f.type)` (an `Iterable`) to a single `SharedMediaType` enum value — an expression that always evaluates to `false`
- Updates `example/lib/main.dart` to demonstrate the correct pattern: iterate over `sharedFiles`, check `file.type` per item using a `switch` statement
- Updates the README **Full Example** to use the same correct pattern
- Adds a highlighted **Tip** callout in the README explicitly warning against the wrong usage

Closes #31

## Root cause

`SharedFile.type` is a property on a single item. To handle multiple shared files by type you must loop and compare `file.type == SharedMediaType.X` — not call `.map(...)` on the whole list and compare the resulting `Iterable` to an enum constant.

## Test plan
- [ ] Share a URL into the example app → `"Shared URL: ..."` is printed
- [ ] Share a plain text string → `"Shared text: ..."` is printed
- [ ] Share an image → `"Shared image path: ..."` is printed
- [ ] Verify Flutter analyzer passes (`flutter analyze`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)