### PR TITLE
fix: null-safe filename handling for MMS content providers (#24)

### DIFF
--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/MyFileDirectory.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/MyFileDirectory.kt
@@ -110,12 +110,15 @@ object MyFileDirectory {
                     val columnIndex = cursor.getColumnIndexOrThrow(column)
                     val fileName = cursor.getString(columnIndex)
                     Log.i("FileDirectory", "File name: $fileName")
-                    val safeName = File(fileName).name
-                    if (safeName.isEmpty()) throw IllegalArgumentException("Invalid file name")
-                    if (safeName.startsWith("/")) throw IllegalArgumentException("Invalid file name")
-                    if (safeName.contains("..")) throw IllegalArgumentException("Invalid file name")
-                    if (!FILE_NAME.matcher(safeName).matches()) throw IllegalArgumentException("Invalid file name")
-                    targetFile = File(context.cacheDir, safeName)
+                    // fileName can be null for MMS/messaging providers — fall through to
+                    // the MIME-type-based filename generated below when that happens.
+                    if (fileName != null) {
+                        val safeName = File(fileName).name
+                        if (safeName.isNotEmpty() && !safeName.startsWith("/")
+                                && !safeName.contains("..") && FILE_NAME.matcher(safeName).matches()) {
+                            targetFile = File(context.cacheDir, safeName)
+                        }
+                    }
                 }
             } finally {
                 cursor?.close()

--- a/lib/flutter_sharing_intent_method_channel.dart
+++ b/lib/flutter_sharing_intent_method_channel.dart
@@ -14,13 +14,15 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
   final methodChannel = const MethodChannel('flutter_sharing_intent');
 
   @visibleForTesting
-  final eventChannel =
-      const EventChannel('flutter_sharing_intent/events-sharing');
+  final eventChannel = const EventChannel(
+    'flutter_sharing_intent/events-sharing',
+  );
 
   @override
   Future<String?> getPlatformVersion() async {
-    final version =
-        await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
     return version;
   }
 
@@ -41,8 +43,9 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
 
   @override
   Stream<List<SharedFile>> getMediaStream() {
-    final stream =
-        eventChannel.receiveBroadcastStream("sharing").cast<String?>();
+    final stream = eventChannel
+        .receiveBroadcastStream("sharing")
+        .cast<String?>();
     return stream.transform<List<SharedFile>>(
       StreamTransformer<String?, List<SharedFile>>.fromHandlers(
         handleData: (String? data, EventSink<List<SharedFile>> sink) {
@@ -50,9 +53,11 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
             sink.add([]);
           } else {
             final encoded = jsonDecode(data);
-            sink.add(encoded
-                .map<SharedFile>((file) => SharedFile.fromJson(file))
-                .toList());
+            sink.add(
+              encoded
+                  .map<SharedFile>((file) => SharedFile.fromJson(file))
+                  .toList(),
+            );
           }
         },
       ),

--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,23 +21,24 @@ class SharedFile {
   /// Post message iOS ONLY
   final String? message;
 
-  SharedFile(
-      {required this.value,
-      this.thumbnail,
-      this.duration,
-      this.type = SharedMediaType.OTHER,
-      this.mimeType,
-      this.message});
+  SharedFile({
+    required this.value,
+    this.thumbnail,
+    this.duration,
+    this.type = SharedMediaType.OTHER,
+    this.mimeType,
+    this.message,
+  });
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value = json['value'] ?? json['path'],
-        thumbnail = json['thumbnail'],
-        duration = json['duration'],
-        type = json['type'] is int
-            ? SharedMediaType.values[json['type']]
-            : SharedMediaType.OTHER,
-        mimeType = json['mimeType'],
-        message = json['message'];
+    : value = json['value'] ?? json['path'],
+      thumbnail = json['thumbnail'],
+      duration = json['duration'],
+      type = json['type'] is int
+          ? SharedMediaType.values[json['type']]
+          : SharedMediaType.OTHER,
+      mimeType = json['mimeType'],
+      message = json['message'];
 
   Map<String, dynamic> toMap() {
     return {

--- a/test/flutter_sharing_intent_method_channel_test.dart
+++ b/test/flutter_sharing_intent_method_channel_test.dart
@@ -12,8 +12,8 @@ void main() {
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      return '42';
-    });
+          return '42';
+        });
   });
 
   tearDown(() {

--- a/test/flutter_sharing_intent_test.dart
+++ b/test/flutter_sharing_intent_test.dart
@@ -13,8 +13,9 @@ class MockFlutterSharingIntentPlatform
 
   @override
   Future<List<SharedFile>> getInitialSharing() {
-    return Future.value(
-        [SharedFile(value: "Test", type: SharedMediaType.TEXT)]);
+    return Future.value([
+      SharedFile(value: "Test", type: SharedMediaType.TEXT),
+    ]);
   }
 
   @override


### PR DESCRIPTION
## Summary

- Fixes a `NullPointerException` crash in `MyFileDirectory.getDataColumn()` when sharing files from MMS/messaging apps (e.g. Google Messages)
- MMS content providers return `null` for the `_display_name` column; the old code passed `null` directly into `File()`, causing an NPE
- Now null-checks `fileName` before use and falls through to the existing MIME-type-based filename generation (`IMG_<timestamp>.jpg`, etc.) when the display name is unavailable

## Root Cause

`ContentResolver.query()` on an MMS `content://` URI returns a cursor where `_display_name` is `null`. The previous code called `File(fileName).name` unconditionally, which throws `NullPointerException` on Android.

## Test plan

- [ ] Share an image via Google Messages (MMS) — should no longer crash
- [ ] Share a normal image/video — filename still resolved from `_display_name` as before
- [ ] Share a file with a path-traversal filename (e.g. `../../etc/passwd`) — sanitization still blocks it
- [ ] Share a file with no MIME type — falls back to `.bin` extension

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)