### PR TITLE
fix: debounce duplicate intents on Samsung/OEM devices (#28)

### DIFF
--- a/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/techind/flutter_sharing_intent/FlutterSharingIntentPlugin.kt
@@ -14,6 +14,7 @@ import android.webkit.MimeTypeMap
 import android.webkit.URLUtil
 import androidx.annotation.NonNull
 import androidx.annotation.VisibleForTesting
+import java.util.Objects
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -44,6 +45,11 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
   /** To store initial & latest value when app is opened from background **/
   private var initialSharing: JSONArray? = null
   private var latestSharing: JSONArray? = null
+
+  // Debounce duplicate intents from Samsung and other OEM launchers that
+  // deliver the same intent more than once within a short window.
+  private var lastIntentHash: Int = 0
+  private var lastIntentTime: Long = 0
 
   /// The MethodChannel that will the communication between Flutter and native Android
   private lateinit var channel : MethodChannel
@@ -94,62 +100,72 @@ class FlutterSharingIntentPlugin: FlutterPlugin, ActivityAware, MethodCallHandle
   }
 
   private fun handleIntent(intent: Intent, initial: Boolean) {
-    val intentFlags = intent.getFlags()
-    if ((intentFlags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == 0){
-      Log.d(TAG,"handleIntent ==>> ${intent.action}, ${intent.type}")
-      when {
-        (intent.type?.startsWith("text") != true)
-                && (intent.action == Intent.ACTION_SEND
-                || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing images or videos (with optional caption text)
+    val intentFlags = intent.flags
+    if ((intentFlags and Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) return
 
+    // Skip duplicate intents delivered within 500ms — seen on Samsung and some other OEM devices.
+    val extraStream = intent.getParcelableExtra<Uri>(Intent.EXTRA_STREAM)?.toString()
+    val intentHash = Objects.hash(intent.action, intent.type, intent.dataString,
+        intent.getStringExtra(Intent.EXTRA_TEXT), extraStream)
+    val now = System.currentTimeMillis()
+    if (intentHash == lastIntentHash && (now - lastIntentTime) < 500L) {
+      Log.d(TAG, "handleIntent: duplicate intent ignored (hash=$intentHash)")
+      return
+    }
+    lastIntentHash = intentHash
+    lastIntentTime = now
 
-          val value = mergeSharingArrays(getSharingUris(intent), getSharingText(intent))
-          if (initial) initialSharing = value
-          latestSharing = value
-          Log.d(TAG,"Image/Video : handleIntent ==>> $value")
-          eventSinkSharing?.success(value?.toString())
-        }
-        (intent.type == null || intent.type?.startsWith("text") == true)
-                && (intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing text (with optional file)
+    Log.d(TAG,"handleIntent ==>> ${intent.action}, ${intent.type}")
+    when {
+      (intent.type?.startsWith("text") != true)
+              && (intent.action == Intent.ACTION_SEND
+              || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing images or videos (with optional caption text)
 
-          val value = mergeSharingArrays(getSharingText(intent), getSharingUris(intent))
-          if (initial) initialSharing = value
-          latestSharing = value
-          Log.d(TAG,"text : handleIntent ==>> $value")
-//          Log.w(TAG,"text : handleIntent ==>> ${eventSinkSharing!=null}")
-          value?.let { eventSinkSharing?.success(it.toString()) }
+        val value = mergeSharingArrays(getSharingUris(intent), getSharingText(intent))
+        if (initial) initialSharing = value
+        latestSharing = value
+        Log.d(TAG,"Image/Video : handleIntent ==>> $value")
+        eventSinkSharing?.success(value?.toString())
+      }
+      (intent.type == null || intent.type?.startsWith("text") == true)
+              && (intent.action == Intent.ACTION_SEND || intent.action == Intent.ACTION_SEND_MULTIPLE) -> { // Sharing text (with optional file)
 
-        }
-        // Explicit handler for URL intents — produces MediaType.URL.
-        // getMediaType() never receives this intent type, so its "url" branch
-        // was removed; this is the single authoritative place for URL handling.
-        intent.action == Intent.ACTION_VIEW -> { // Opening URL
-          val value = JSONArray().put(
-            JSONObject()
-              .put("value", intent.dataString)
-              .put("type", MediaType.URL.ordinal)
-          )
-          if (value == null) Log.w(TAG,"ACTION_VIEW : handleIntent ==>> value is null, skipping assignment")
-          if (initial && value != null) initialSharing = value
-          latestSharing = value
-          Log.d(TAG,"ACTION_VIEW : handleIntent ==>> $value")
-          eventSinkSharing?.success(value?.toString())
-        }
-        // Explicit handler for web-search intents — produces MediaType.WEB_SEARCH.
-        // getMediaType() never receives this intent type, so its "web_search" branch
-        // was removed; this is the single authoritative place for web-search handling.
-        intent.action == Intent.ACTION_WEB_SEARCH -> {
-            val value = JSONArray().put(
-                JSONObject()
-                    .put("value", intent.getStringExtra(SearchManager.QUERY))
-                    .put("type", MediaType.WEB_SEARCH.ordinal)
-            )
-            if (value == null) Log.w(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> value is null, skipping assignment")
-            if (initial && value != null) initialSharing = value
-            latestSharing = value
-            Log.d(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> $value")
-            eventSinkSharing?.success(value?.toString())
-        }
+        val value = mergeSharingArrays(getSharingText(intent), getSharingUris(intent))
+        if (initial) initialSharing = value
+        latestSharing = value
+        Log.d(TAG,"text : handleIntent ==>> $value")
+        value?.let { eventSinkSharing?.success(it.toString()) }
+
+      }
+      // Explicit handler for URL intents — produces MediaType.URL.
+      // getMediaType() never receives this intent type, so its "url" branch
+      // was removed; this is the single authoritative place for URL handling.
+      intent.action == Intent.ACTION_VIEW -> { // Opening URL
+        val value = JSONArray().put(
+          JSONObject()
+            .put("value", intent.dataString)
+            .put("type", MediaType.URL.ordinal)
+        )
+        if (value == null) Log.w(TAG,"ACTION_VIEW : handleIntent ==>> value is null, skipping assignment")
+        if (initial && value != null) initialSharing = value
+        latestSharing = value
+        Log.d(TAG,"ACTION_VIEW : handleIntent ==>> $value")
+        eventSinkSharing?.success(value?.toString())
+      }
+      // Explicit handler for web-search intents — produces MediaType.WEB_SEARCH.
+      // getMediaType() never receives this intent type, so its "web_search" branch
+      // was removed; this is the single authoritative place for web-search handling.
+      intent.action == Intent.ACTION_WEB_SEARCH -> {
+        val value = JSONArray().put(
+          JSONObject()
+            .put("value", intent.getStringExtra(SearchManager.QUERY))
+            .put("type", MediaType.WEB_SEARCH.ordinal)
+        )
+        if (value == null) Log.w(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> value is null, skipping assignment")
+        if (initial && value != null) initialSharing = value
+        latestSharing = value
+        Log.d(TAG,"ACTION_WEB_SEARCH : handleIntent ==>> $value")
+        eventSinkSharing?.success(value?.toString())
       }
     }
   }

--- a/lib/flutter_sharing_intent_method_channel.dart
+++ b/lib/flutter_sharing_intent_method_channel.dart
@@ -14,13 +14,15 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
   final methodChannel = const MethodChannel('flutter_sharing_intent');
 
   @visibleForTesting
-  final eventChannel =
-      const EventChannel('flutter_sharing_intent/events-sharing');
+  final eventChannel = const EventChannel(
+    'flutter_sharing_intent/events-sharing',
+  );
 
   @override
   Future<String?> getPlatformVersion() async {
-    final version =
-        await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
     return version;
   }
 
@@ -41,8 +43,9 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
 
   @override
   Stream<List<SharedFile>> getMediaStream() {
-    final stream =
-        eventChannel.receiveBroadcastStream("sharing").cast<String?>();
+    final stream = eventChannel
+        .receiveBroadcastStream("sharing")
+        .cast<String?>();
     return stream.transform<List<SharedFile>>(
       StreamTransformer<String?, List<SharedFile>>.fromHandlers(
         handleData: (String? data, EventSink<List<SharedFile>> sink) {
@@ -50,9 +53,11 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
             sink.add([]);
           } else {
             final encoded = jsonDecode(data);
-            sink.add(encoded
-                .map<SharedFile>((file) => SharedFile.fromJson(file))
-                .toList());
+            sink.add(
+              encoded
+                  .map<SharedFile>((file) => SharedFile.fromJson(file))
+                  .toList(),
+            );
           }
         },
       ),

--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,23 +21,24 @@ class SharedFile {
   /// Post message iOS ONLY
   final String? message;
 
-  SharedFile(
-      {required this.value,
-      this.thumbnail,
-      this.duration,
-      this.type = SharedMediaType.OTHER,
-      this.mimeType,
-      this.message});
+  SharedFile({
+    required this.value,
+    this.thumbnail,
+    this.duration,
+    this.type = SharedMediaType.OTHER,
+    this.mimeType,
+    this.message,
+  });
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value = json['value'] ?? json['path'],
-        thumbnail = json['thumbnail'],
-        duration = json['duration'],
-        type = json['type'] is int
-            ? SharedMediaType.values[json['type']]
-            : SharedMediaType.OTHER,
-        mimeType = json['mimeType'],
-        message = json['message'];
+    : value = json['value'] ?? json['path'],
+      thumbnail = json['thumbnail'],
+      duration = json['duration'],
+      type = json['type'] is int
+          ? SharedMediaType.values[json['type']]
+          : SharedMediaType.OTHER,
+      mimeType = json['mimeType'],
+      message = json['message'];
 
   Map<String, dynamic> toMap() {
     return {

--- a/test/flutter_sharing_intent_method_channel_test.dart
+++ b/test/flutter_sharing_intent_method_channel_test.dart
@@ -12,8 +12,8 @@ void main() {
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      return '42';
-    });
+          return '42';
+        });
   });
 
   tearDown(() {

--- a/test/flutter_sharing_intent_test.dart
+++ b/test/flutter_sharing_intent_test.dart
@@ -13,8 +13,9 @@ class MockFlutterSharingIntentPlatform
 
   @override
   Future<List<SharedFile>> getInitialSharing() {
-    return Future.value(
-        [SharedFile(value: "Test", type: SharedMediaType.TEXT)]);
+    return Future.value([
+      SharedFile(value: "Test", type: SharedMediaType.TEXT),
+    ]);
   }
 
   @override


### PR DESCRIPTION
## Summary

- Fixes repeated delivery of the same sharing intent on Samsung and other OEM devices
- Some launchers fire the same `ACTION_SEND` intent twice within milliseconds; this caused apps to process the same shared file/text multiple times
- Adds a 500ms debounce keyed on a hash of the intent's action, type, data string, `EXTRA_TEXT`, and `EXTRA_STREAM` URI — if the same hash arrives within the window the second delivery is silently dropped
- Also converts the `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` guard to an early return, removing one nesting level from `handleIntent`

## Test plan

- [ ] Share an image on a Samsung device — received exactly once (not twice)
- [ ] Share text on a Samsung device — received exactly once
- [ ] Share two different images in quick succession — both received correctly (different hashes)
- [ ] Share the same image again after >500ms — received correctly (window elapsed)
- [ ] Launch the app normally from the launcher without sharing — no spurious intent delivered

Fixes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)