### PR TITLE
docs: add setup notes and troubleshooting for common issues (#15 #26 #46 #49 #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,16 @@ Add the following intent filters to your [android/app/src/main/AndroidManifest.x
 ....
 ```
 
+> **Note:** `android:launchMode="singleTask"` is required on your `MainActivity`. Without it, Android
+> creates a new activity instance for each share intent instead of routing it to the running app,
+> which means `getMediaStream()` never fires for background shares. If you need a different launch
+> mode for another reason, `singleTop` also works.
+
+> **Tip – Limiting which file types appear in the share sheet:** Each `<intent-filter>` block above
+> registers your app for that MIME type. Remove any filters you don't need and your app will no
+> longer appear in the system share sheet for those types.  For example, to receive only images and
+> videos, keep only the `image/*` and `video/*` filters and remove the others.
+
 ## IOS
 
 #### 1. Create Share Extension
@@ -183,6 +193,11 @@ end
 * Add a new container with the name of your choice. For example `group.MyContainer` in the example project its `group.com.techind.flutterSharingIntentExample`
 * Add User-Defined(`Build Settings -> +`) string `CUSTOM_GROUP_ID` in **BOTH** Targets: `Runner` and `Share Extension` and set value to group id created above. You can use different group ids depends on your flavor schemes
 
+> **Important:** The `CUSTOM_GROUP_ID` value **must be identical** in both the Runner target and the
+> Share Extension target. A mismatch is the most common reason the sharing callback never fires —
+> the extension writes shared data to one App Group container while the plugin reads from a different
+> one. Double-check `Build Settings → User-Defined → CUSTOM_GROUP_ID` in both targets after any
+> rename or flavor change.
 
 ##### Make sure the deployment target for Runner.app and the share extension is the same.
 
@@ -431,3 +446,20 @@ class _MyAppState extends State<MyApp> {
   * This build cycle is triggered when the `Embed App Extensions` phase runs after `Thin Binary` in the Runner target's Build Phases. Xcode ends up with a circular dependency between copying the `.appex` bundle and stripping/processing binaries.
   * Fix: In Xcode, open your **Runner** target → **Build Phases** tab. Drag the **Embed Foundation Extensions** (or **Embed App Extensions**) phase so it appears **above** the **Thin Binary** phase. Clean the build folder (`Product → Clean Build Folder`) and rebuild.
   * Reference: [Flutter issue #135739](https://github.com/flutter/flutter/issues/135739)
+
+* Error (Xcode): `'Flutter/Flutter.h' file not found`
+  * This usually means `use_frameworks!` is missing from your `ios/Podfile`. The plugin requires dynamic frameworks.
+  * Fix: Add `use_frameworks!` inside the `target 'Runner' do` block in your `ios/Podfile` (see the Podfile snippet in the iOS Setup section above), then run `pod install` again.
+
+* iOS: App loads after sharing, but the sharing callback never fires / `getMediaStream()` receives no data
+  * The most common cause is an **App Group ID mismatch** between the Runner target and the Share Extension target.  The Share Extension writes to one group container and the plugin reads from a different one, so the data is never delivered.
+  * Fix: In Xcode, verify that the `CUSTOM_GROUP_ID` User-Defined build setting is set to **exactly the same string** in both the `Runner` target and the `Share Extension` target (Build Settings → User-Defined → CUSTOM_GROUP_ID).  Also confirm both targets have the same App Group enabled under Signing & Capabilities.
+  * Additional check: make sure `AppGroupId` in both `ios/Runner/Info.plist` and `ios/Share Extension/Info.plist` is `$(CUSTOM_GROUP_ID)` (not a hard-coded string that might differ between flavors).
+
+* How do I get the file extension from a shared file?
+  * The `SharedFile.mimeType` field contains the MIME type string (e.g. `"image/jpeg"`, `"application/pdf"`).  Derive the extension from it:
+  ```dart
+  import 'package:mime/mime.dart'; // add mime: ^1.0.0 to pubspec.yaml
+  final ext = extensionFromMime(file.mimeType ?? ''); // e.g. "jpeg", "pdf"
+  ```
+  * Alternatively, use `path` package: `extension(file.value)` returns the extension from the cached file path (e.g. `".jpg"`).  This works for most shared files but may return an empty string for content URIs that were resolved without an extension.

--- a/lib/flutter_sharing_intent_method_channel.dart
+++ b/lib/flutter_sharing_intent_method_channel.dart
@@ -14,13 +14,15 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
   final methodChannel = const MethodChannel('flutter_sharing_intent');
 
   @visibleForTesting
-  final eventChannel =
-      const EventChannel('flutter_sharing_intent/events-sharing');
+  final eventChannel = const EventChannel(
+    'flutter_sharing_intent/events-sharing',
+  );
 
   @override
   Future<String?> getPlatformVersion() async {
-    final version =
-        await methodChannel.invokeMethod<String>('getPlatformVersion');
+    final version = await methodChannel.invokeMethod<String>(
+      'getPlatformVersion',
+    );
     return version;
   }
 
@@ -41,8 +43,9 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
 
   @override
   Stream<List<SharedFile>> getMediaStream() {
-    final stream =
-        eventChannel.receiveBroadcastStream("sharing").cast<String?>();
+    final stream = eventChannel
+        .receiveBroadcastStream("sharing")
+        .cast<String?>();
     return stream.transform<List<SharedFile>>(
       StreamTransformer<String?, List<SharedFile>>.fromHandlers(
         handleData: (String? data, EventSink<List<SharedFile>> sink) {
@@ -50,9 +53,11 @@ class MethodChannelFlutterSharingIntent extends FlutterSharingIntentPlatform {
             sink.add([]);
           } else {
             final encoded = jsonDecode(data);
-            sink.add(encoded
-                .map<SharedFile>((file) => SharedFile.fromJson(file))
-                .toList());
+            sink.add(
+              encoded
+                  .map<SharedFile>((file) => SharedFile.fromJson(file))
+                  .toList(),
+            );
           }
         },
       ),

--- a/lib/model/sharing_file.dart
+++ b/lib/model/sharing_file.dart
@@ -21,23 +21,24 @@ class SharedFile {
   /// Post message iOS ONLY
   final String? message;
 
-  SharedFile(
-      {required this.value,
-      this.thumbnail,
-      this.duration,
-      this.type = SharedMediaType.OTHER,
-      this.mimeType,
-      this.message});
+  SharedFile({
+    required this.value,
+    this.thumbnail,
+    this.duration,
+    this.type = SharedMediaType.OTHER,
+    this.mimeType,
+    this.message,
+  });
 
   SharedFile.fromJson(Map<String, dynamic> json)
-      : value = json['value'] ?? json['path'],
-        thumbnail = json['thumbnail'],
-        duration = json['duration'],
-        type = json['type'] is int
-            ? SharedMediaType.values[json['type']]
-            : SharedMediaType.OTHER,
-        mimeType = json['mimeType'],
-        message = json['message'];
+    : value = json['value'] ?? json['path'],
+      thumbnail = json['thumbnail'],
+      duration = json['duration'],
+      type = json['type'] is int
+          ? SharedMediaType.values[json['type']]
+          : SharedMediaType.OTHER,
+      mimeType = json['mimeType'],
+      message = json['message'];
 
   Map<String, dynamic> toMap() {
     return {

--- a/test/flutter_sharing_intent_method_channel_test.dart
+++ b/test/flutter_sharing_intent_method_channel_test.dart
@@ -12,8 +12,8 @@ void main() {
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
         .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-      return '42';
-    });
+          return '42';
+        });
   });
 
   tearDown(() {

--- a/test/flutter_sharing_intent_test.dart
+++ b/test/flutter_sharing_intent_test.dart
@@ -13,8 +13,9 @@ class MockFlutterSharingIntentPlatform
 
   @override
   Future<List<SharedFile>> getInitialSharing() {
-    return Future.value(
-        [SharedFile(value: "Test", type: SharedMediaType.TEXT)]);
+    return Future.value([
+      SharedFile(value: "Test", type: SharedMediaType.TEXT),
+    ]);
   }
 
   @override


### PR DESCRIPTION
## Summary

Adds missing documentation that addresses five open questions/issues without requiring code changes:

- **#26** — Adds a note explaining that `android:launchMode="singleTask"` is required; without it Android creates a new activity per share and `getMediaStream()` never fires for background shares
- **#15** — Adds a tip explaining that removing specific `<intent-filter>` blocks from `AndroidManifest.xml` hides the app from the share sheet for those MIME types, enabling type-level filtering
- **#46** — Adds a prominent warning that the `CUSTOM_GROUP_ID` build setting must be **identical** in both the `Runner` and `Share Extension` targets; mismatch is the #1 reason the iOS callback never fires
- **#60** — Adds a troubleshooting entry for the `'Flutter/Flutter.h' file not found` Xcode error, pointing to the `use_frameworks!` Podfile requirement already shown in the iOS setup section
- **#49** — Adds a troubleshooting tip showing how to derive the file extension from `SharedFile.mimeType` using the `mime` package or the `path` package's `extension()` function

## Test plan

- [ ] Read through the Android Setup section — `singleTask` note and MIME filter tip are clear
- [ ] Read through the iOS Setup section — App Group ID warning is visible and actionable
- [ ] Read through Troubleshooting — new entries for `Flutter/Flutter.h`, callback-not-firing, and file-extension are easy to find

Closes #15
Closes #26
Closes #46
Closes #49
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)