### PR TITLE
fix: Xcode 16 build issues — SPM Swift 5 mode, explicit modules, lint Podfile

### DIFF
--- a/ios/Classes/FSIShareViewController.swift
+++ b/ios/Classes/FSIShareViewController.swift
@@ -230,7 +230,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
                     self.saveAndRedirect()
                 }
             } else {
-                print("FSIShare: No shared media → stopping.")
+                self.log("No shared media — stopping.")
                 self.completeAndExit()
             }
         }

--- a/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
@@ -343,7 +343,6 @@ public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, Fl
             let encodedData = try JSONDecoder().decode([SharingFile].self, from: data)
             return encodedData
         } catch {
-            print("Decoding error:", error.localizedDescription)
             return []
         }
     }

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -31,6 +31,12 @@ let package = Package(
             publicHeadersPath: "Classes",
             cSettings: [
                 .headerSearchPath("Classes"),
+            ],
+            swiftSettings: [
+                // Xcode 16 defaults to Swift 6 strict concurrency — opt into
+                // Swift 5 mode so existing completion-handler and DispatchSemaphore
+                // patterns don't trigger concurrency errors.
+                .swiftLanguageVersion(.v5),
             ]
         ),
     ]

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,8 +1,7 @@
 platform :ios, '12.0'
 
-target 'Runner' do
-  # ... existing pods
-
-  # Add the pod for the external library
-  pod 'Evergage', '1.4.0'
+# This Podfile is used only for `pod lib lint`. Consumer apps use
+# example/ios/Podfile instead.
+target 'flutter_sharing_intent' do
+  use_frameworks!
 end

--- a/ios/flutter_sharing_intent.podspec
+++ b/ios/flutter_sharing_intent.podspec
@@ -33,7 +33,8 @@ Pod::Spec.new do |s|
   }
 
   s.user_target_xcconfig = {
-    'CLANG_ENABLE_EXPLICIT_MODULES' => 'NO'
+    'CLANG_ENABLE_EXPLICIT_MODULES' => 'NO',
+    'SWIFT_EXPLICIT_MODULES_ENABLED' => 'NO',
   }
 
   # Add resource bundle for Apple manifest policy


### PR DESCRIPTION
## Summary

- **`ios/flutter_sharing_intent.podspec`** — add `SWIFT_EXPLICIT_MODULES_ENABLED=NO` to `user_target_xcconfig`. Previously only `CLANG_ENABLE_EXPLICIT_MODULES=NO` was set; adding the Swift counterpart ensures the explicit module scanner doesn't try to resolve `Flutter` as a Swift module in consumer apps even without the Podfile `post_install` patch.

- **`ios/Package.swift`** — add `swiftSettings: [.swiftLanguageVersion(.v5)]`. Xcode 16 with `swift-tools-version: 5.9` can default to Swift 6 strict concurrency checking, turning `DispatchSemaphore` and completion-handler patterns into build errors. Opting into Swift 5 mode makes SPM-integrated builds safe.

- **`ios/Podfile`** — remove stale Evergage pod reference (wrong plugin scaffold leftover that would cause `pod lib lint` to fail). Replaced with a minimal placeholder; consumer apps use `example/ios/Podfile`.

- **`ios/Classes/FSIShareViewController.swift`** — move "no shared media" log behind the `debugLogs`-gated `log()` helper instead of bare `print()`.

- **`ios/Classes/SwiftFlutterSharingIntentPlugin.swift`** — remove bare `print()` from JSON decode catch block; silent empty return is the correct behavior.

## Test plan

- [ ] `pod lib lint ios/flutter_sharing_intent.podspec --allow-warnings` passes
- [ ] `flutter build ios` in `example/` succeeds on Xcode 16
- [ ] No `SWIFT_EXPLICIT_MODULES` or `'Flutter/Flutter.h' file not found` errors in a clean build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)