### PR TITLE
fix(ios): restore host-app redirect (regression on main) and report decoded file paths

### DIFF
--- a/ios/Classes/FSIShareViewController.swift
+++ b/ios/Classes/FSIShareViewController.swift
@@ -261,7 +261,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
             let filename = getFileName(from: url, type: .image)
             if let dst = containerURL()?.appendingPathComponent(filename) {
                 if copyFile(at: url, to: dst) {
-                    sharedMedia.append(SharingFile(value: dst.absoluteString, mimeType: url.mimeType(), thumbnail: nil, duration: nil, type: .image))
+                    sharedMedia.append(SharingFile(value: dst.path, mimeType: url.mimeType(), thumbnail: nil, duration: nil, type: .image))
                 }
             }
         } else if let img = data as? UIImage {
@@ -295,7 +295,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
             let filename = getFileName(from: url, type: .file)
             if let dst = containerURL()?.appendingPathComponent(filename) {
                 if copyFile(at: url, to: dst) {
-                    sharedMedia.append(SharingFile(value: dst.absoluteString, mimeType: url.mimeType(), thumbnail: nil, duration: nil, type: .file))
+                    sharedMedia.append(SharingFile(value: dst.path, mimeType: url.mimeType(), thumbnail: nil, duration: nil, type: .file))
                 }
             }
         }
@@ -304,7 +304,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
             if let dst = containerURL()?.appendingPathComponent(filename) {
                 do {
                     try raw.write(to: dst)
-                    sharedMedia.append(SharingFile(value: dst.absoluteString, mimeType: "application/octet-stream", thumbnail: nil, duration: nil, type: .file))
+                    sharedMedia.append(SharingFile(value: dst.path, mimeType: "application/octet-stream", thumbnail: nil, duration: nil, type: .file))
                 } catch {}
             }
         }
@@ -320,8 +320,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
         do {
             if let d = image.pngData() {
                 try d.write(to: dst)
-                let decoded = dst.absoluteString.removingPercentEncoding ?? dst.absoluteString
-                return SharingFile(value: decoded, mimeType: "image/png", thumbnail: nil, duration: nil, type: .image)
+                return SharingFile(value: dst.path, mimeType: "image/png", thumbnail: nil, duration: nil, type: .image)
             }
         } catch {
             log("writeTempImage error: \(error)")
@@ -442,7 +441,7 @@ open class FSIShareViewController: SLComposeServiceViewController {
         let thumbnailPath = getThumbnailPath(for: forVideo)
         
         if FileManager.default.fileExists(atPath: thumbnailPath.path) {
-            return SharingFile(value: forVideo.absoluteString, mimeType: forVideo.mimeType(), thumbnail: thumbnailPath.absoluteString, duration: Int(duration), type: .video)
+            return SharingFile(value: forVideo.path, mimeType: forVideo.mimeType(), thumbnail: thumbnailPath.path, duration: Int(duration), type: .video)
         }
         
         let gen = AVAssetImageGenerator(asset: asset)
@@ -455,14 +454,14 @@ open class FSIShareViewController: SLComposeServiceViewController {
             let cg = try gen.copyCGImage(at: time, actualTime: nil)
             if let data = UIImage(cgImage: cg).jpegData(compressionQuality: 0.8) {
                 try data.write(to: thumbnailPath)
-                return SharingFile(value: forVideo.absoluteString, mimeType: forVideo.mimeType(), thumbnail: thumbnailPath.absoluteString, duration: Int(duration), type: .video)
+                return SharingFile(value: forVideo.path, mimeType: forVideo.mimeType(), thumbnail: thumbnailPath.path, duration: Int(duration), type: .video)
             }
         } catch {
             log("getSharedMediaFile thumbnail error: \(error)")
         }
         
         // fallback
-        return SharingFile(value: forVideo.absoluteString, mimeType: forVideo.mimeType(), thumbnail: nil, duration: Int(duration), type: .video)
+        return SharingFile(value: forVideo.path, mimeType: forVideo.mimeType(), thumbnail: nil, duration: Int(duration), type: .video)
     }
     
     private func getThumbnailPath(for url: URL) -> URL {

--- a/ios/Classes/FSIShareViewController.swift
+++ b/ios/Classes/FSIShareViewController.swift
@@ -352,25 +352,40 @@ open class FSIShareViewController: SLComposeServiceViewController {
         }
         guard let url = URL(string: encoded) else { completeAndExit(); return }
 
-        // On iOS 18+ the undocumented openURL: responder-chain hack no longer works
-        // inside Share Extensions because UIApplication is not reachable from the
-        // extension's responder chain. Use the documented NSExtensionContext API instead.
-        if #available(iOS 18.0, *) {
+        // Walking the responder chain for UIApplication is undocumented, but it is
+        // the only mechanism that actually opens a custom scheme from a Share
+        // extension — verified working on iOS 18 hardware. Do not gate it behind an
+        // availability check: NSExtensionContext.open is the documented API but is
+        // honoured only for the Today and iMessage extension points, so for a Share
+        // extension it silently does nothing and the host app never comes forward.
+        // It is kept as a fallback in case a future iOS closes the responder route.
+        if !openViaResponderChain(url) {
+            log("redirectToHostApp: no responder could open \(url), falling back to extensionContext")
             extensionContext?.open(url, completionHandler: nil)
-        } else {
-            // Earlier iOS versions don't expose extensionContext?.open(_:completionHandler:),
-            // so we fall back to walking the responder chain to find an object that
-            // responds to openURL: (typically UIApplication) and invoke it directly.
-            let sel = sel_registerName("openURL:")
-            var responder: UIResponder? = self
-            while responder != nil {
-                if responder?.responds(to: sel) ?? false { _ = responder?.perform(sel, with: url) }
-                responder = responder?.next
-            }
         }
         extensionContext?.completeRequest(returningItems: [], completionHandler: nil)
     }
-    
+
+    /// Walks up from this view controller looking for something able to open a
+    /// URL. Returns whether the open was actually dispatched, so the caller can
+    /// fall back rather than fail silently.
+    private func openViaResponderChain(_ url: URL) -> Bool {
+        let sel = sel_registerName("openURL:")
+        var responder: UIResponder? = self
+        while let current = responder {
+            if let application = current as? UIApplication {
+                application.open(url, options: [:], completionHandler: nil)
+                return true
+            }
+            if current.responds(to: sel) {
+                _ = current.perform(sel, with: url)
+                return true
+            }
+            responder = current.next
+        }
+        return false
+    }
+
     // MARK: - File / thumbnail / metadata helpers
     func getExtension(from url: URL, type: SharingFileType) -> String {
         let parts = url.lastPathComponent.components(separatedBy: ".")
@@ -504,7 +519,11 @@ open class FSIShareViewController: SLComposeServiceViewController {
     }
     
     // MARK: - Logging
-    private func log(_ s: String) { if debugLogs { print("[FSIShareVC] \(s)") } }
+    // NSLog rather than print: a Share extension's stdout is not captured, so
+    // print() is only visible with a debugger already attached. NSLog reaches the
+    // unified log, where `log stream --predicate 'process == "ShareExtension"'`
+    // can pick it up without attaching to a process that is not running yet.
+    private func log(_ s: String) { if debugLogs { NSLog("[FSIShareVC] %@", s) } }
     
 }
 

--- a/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftFlutterSharingIntentPlugin.swift
@@ -310,8 +310,19 @@ public class SwiftFlutterSharingIntentPlugin: NSObject, FlutterStreamHandler, Fl
                   return nil
               }
         
-        if (identifier.starts(with: "file://") || identifier.starts(with: "/var/mobile/Media") || identifier.starts(with: "/private/var/mobile")) {
-            return identifier.replacingOccurrences(of: "file://", with: "")
+        // A file URL — only produced by older extension builds, which reported
+        // `absoluteString`. Go through URL so percent-escapes (umlauts, "#",
+        // spaces) are decoded back into a usable filesystem path.
+        if identifier.starts(with: "file://") {
+            return URL(string: identifier)?.path
+                ?? identifier.replacingOccurrences(of: "file://", with: "")
+        }
+        // Already an absolute filesystem path. Covers the device container
+        // (/private/var/mobile/...) and the simulator's CoreSimulator path,
+        // which no fixed prefix can match. Photos local identifiers are UUID
+        // based and never start with "/".
+        if identifier.starts(with: "/") {
+            return identifier
         }
         guard let phAsset = PHAsset.fetchAssets(
                  withLocalIdentifiers: [identifier],


### PR DESCRIPTION
Two independent iOS fixes in the Share extension. They are unrelated, but both touch `FSIShareViewController.swift`, so separate PRs would conflict — hence one PR, two clearly scoped commits.

---

## 1. `main` no longer opens the host app at all (regression)

**Commit:** `fix(ios): restore the responder-chain redirect to the host app`

`c093cea` (merged as #103, "address issue #55") changed `redirectToHostApp()` to call `NSExtensionContext.open` on iOS 18+, replacing the responder-chain `openURL:` walk. The stated rationale was:

> On iOS 18+ the undocumented openURL: responder-chain hack no longer works inside Share Extensions because UIApplication is not reachable from the extension's responder chain.

That premise does not hold. `NSExtensionContext.open` is honoured only for the Today and iMessage extension points — from a Share extension it silently does nothing and returns no error. Meanwhile `UIApplication` *is* still reachable from the responder chain on iOS 18.

**Effect on `main` today:** the extension loads the attachments, copies them into the app group, writes `SharingKey`, calls `redirectToHostApp()` — and the host app never comes forward. The share sheet simply dismisses. Every consumer of `main` is affected; the published 2.0.4 is not, since it predates `c093cea`.

**How this was established**

- Attached LLDB to the `ShareExtension` process on an iPhone running iOS 18. `redirectToHostApp()` is reached and returns normally; the app does not open.
- The same device, same build settings, on published 2.0.4 — which walks the responder chain unconditionally — opens the host app correctly. That is the direct A/B: the only difference in that code path is which mechanism is used.

**The fix**

Try the responder chain first, unconditionally, and keep `NSExtensionContext.open` as a fallback in case a future iOS closes that route:

```swift
if !openViaResponderChain(url) {
    log("redirectToHostApp: no responder could open \(url), falling back to extensionContext")
    extensionContext?.open(url, completionHandler: nil)
}
```

The walk now returns whether it actually dispatched the open, so a failure triggers the fallback instead of being lost silently — which is what made the original failure invisible. Where the chain yields a real `UIApplication` it calls the proper `open(_:options:completionHandler:)`.

Also switches `log()` from `print` to `NSLog`. A Share extension's stdout is not captured, so `print` output is only visible with a debugger already attached — precisely the situation you cannot reach when the extension exits on its own. Still gated behind `debugLogs`.

---

## 2. Shared files with non-ASCII or reserved characters in the filename are unusable

**Commit:** `fix(ios): report decoded file paths from the share extension`

Affects the published 2.0.4 as well as `main`.

`handleFileItem` / `handleImageItem` / `getSharedMediaFile` report `URL.absoluteString` as the file's `value`. That is a *URL string*, so anything URL-unsafe is percent-encoded. The host-app side (`getAbsolutePath`) only strips the `file://` scheme and never decodes, so Dart receives a path that does not exist on disk:

| Filename on disk | Reported to Dart | Escaped because |
|---|---|---|
| `Filename-With-Umlaut-Ü.txt` | `Filename-With-Umlaut-U%CC%88.txt` | non-ASCII (NFD `U` + U+0308) |
| `Filename-With-Hash-#.pdf` | `Filename-With-Hash-%23.pdf` | `#` is URL-reserved |

```
PathNotFoundException: Cannot retrieve length of file,
path = '/private/var/mobile/Containers/Shared/AppGroup/<id>/Filename-With-Umlaut-U%CC%88.txt'
(OS Error: No such file or directory, errno = 2)
```

The copy itself succeeds and the file is on disk under its correct name — only the reported path is wrong. Spaces break the same way. The bug is already half-acknowledged in the codebase: `writeTempImage` applies `.removingPercentEncoding` as a workaround, while the other five call sites do not.

**The fix**

Use `URL.path` for all file payloads — image, file, raw data, temp image, and video including thumbnails. `.url`-type shares keep `absoluteString`, since those are genuine web links rather than filesystem paths. The `removingPercentEncoding` workaround in `writeTempImage` becomes redundant and is dropped.

`getAbsolutePath` is hardened to match. It keyed off three hardcoded prefixes (`file://`, `/var/mobile/Media`, `/private/var/mobile`); a bare path works on device but matches none of them on the Simulator, whose container lives under `.../CoreSimulator/...`. It would have fallen through to a `PHAsset` lookup, returned nil, and the caller's `guard` silently drops every file that resolves to nil. It now accepts any absolute path, and routes legacy `file://` values through `URL` so they are decoded rather than merely stripped — meaning a payload written to the app group by an older build still resolves.

---

## Testing

Both fixes verified on physical hardware — an iPhone running iOS 18, which is the exact configuration the `#available(iOS 18.0, *)` branch in `c093cea` targets.

**Fix 1 (redirect).** Tested in isolation: a branch built from the published 2.0.4 sources plus fix 2, with this commit's redirect change as the only other difference, so `openViaResponderChain` was the single variable. Result: the share sheet opens the host app and the shared file arrives. For contrast, on current `main` the same device reaches `redirectToHostApp()` — confirmed with an LLDB breakpoint — and returns without the app ever appearing.

**Fix 2 (paths).** A file with an umlaut in its name and a file with `#` in its name both import correctly, where both previously threw `PathNotFoundException`.

No Dart-side or Android changes.
